### PR TITLE
COD-25: Fix start command hidden directory detection

### DIFF
--- a/codery-docs/.codery/commands/codery/start.md
+++ b/codery-docs/.codery/commands/codery/start.md
@@ -1,5 +1,5 @@
 ---
-allowed-tools: Read, TodoWrite
+allowed-tools: Read, TodoWrite, Bash
 description: Initialize the Codery system and start in Mirror Mode
 ---
 
@@ -8,7 +8,7 @@ description: Initialize the Codery system and start in Mirror Mode
 Initialize the Codery system by:
 
 1. Read the CLAUDE.md file in the project root
-2. Check for and read .codery/application-docs.md if it exists  
+2. Check for and read .codery/application-docs.md if it exists (use `ls -la` via Bash to check for hidden directories, not the LS tool)
 3. Check for and read .codery/Retrospective.md to learn from past sessions (if exists)
 4. Fully adopt the Codery methodology and all its roles, workflows, and protocols
 5. Begin operating under the Codery system guidelines


### PR DESCRIPTION
## Summary
- Added Bash tool to start.md allowed-tools  
- Added instruction to use `ls -la` instead of LS tool for hidden directory detection
- Fixes issue where .codery directory wasn't detected properly

## Problem
The start command was using the LS tool which doesn't show hidden directories (those starting with a dot). This caused the AI to incorrectly report that .codery directory didn't exist.

## Solution  
Updated start.md to:
1. Include Bash in allowed-tools
2. Explicitly instruct to use `ls -la` via Bash for checking hidden directories

## Test Plan
- [ ] Run `/codery:start` in a project with existing .codery directory
- [ ] Verify it correctly detects and reads .codery/application-docs.md
- [ ] Verify it correctly detects and reads .codery/Retrospective.md

Fixes #COD-25

🤖 Generated with [Claude Code](https://claude.ai/code)