### PR TITLE
fix(skills): hybrid descriptions with natural keywords for auto-invocation (COD-44)

### DIFF
--- a/codery-docs/.codery/skills/codery-audit/SKILL.md
+++ b/codery-docs/.codery/skills/codery-audit/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Review a PR with linked JIRA context, discuss findings, and generate report. Use when code changes need quality assessment — reviewing a PR, checking if changes are ready to merge, auditing code for issues, or getting feedback on implementation before merging.
+description: Review a PR with linked JIRA context, discuss findings, and generate report. Use when reviewing a PR, auditing code, doing a code review, checking if changes are ready to merge, or getting feedback on implementation before merging.
 argument-hint: <PR-number or ticket-id>
 ---
 

--- a/codery-docs/.codery/skills/codery-changelog/SKILL.md
+++ b/codery-docs/.codery/skills/codery-changelog/SKILL.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Edit, Write, Bash
-description: Analyze git history and update CHANGELOG.md with current branch changes. Use when the changelog needs to reflect completed work on a branch — after finishing implementation, when preparing for release, or when documenting what changed.
+description: Analyze git history and update CHANGELOG.md with current branch changes. Use when updating the changelog, writing release notes, checking what changed on a branch, or preparing for a release after implementation is complete.
 argument-hint: [ticket-id]
 ---
 

--- a/codery-docs/.codery/skills/codery-docs-check/SKILL.md
+++ b/codery-docs/.codery/skills/codery-docs-check/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Check if documentation needs updates based on code changes. Use when code changes may have made documentation outdated — before merging a PR, after significant implementation work, or when ensuring docs stay in sync with the codebase.
+description: Check if documentation needs updates based on code changes. Use when checking if docs need updating, verifying documentation is in sync before merging a PR, or after significant implementation work that may have made docs outdated.
 argument-hint: [PR-number]
 ---
 

--- a/codery-docs/.codery/skills/codery-release/SKILL.md
+++ b/codery-docs/.codery/skills/codery-release/SKILL.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Edit, Write, Bash
-description: Create release branch with versioned changelog following Git Flow. Use when a completed body of work is ready to be versioned and released — cutting a new release, preparing a release branch, or versioning the changelog for deployment.
+description: Create release branch with versioned changelog following Git Flow. Use when creating a release, cutting a release branch, preparing for deployment, or versioning completed work for a new release.
 argument-hint: [version]
 ---
 

--- a/codery-docs/.codery/skills/codery-retrospective/SKILL.md
+++ b/codery-docs/.codery/skills/codery-retrospective/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Self-introspective analysis for session review and learning. Use when a work session is wrapping up, when reflecting on what went well or poorly, or when capturing learnings from the current session for future improvement.
+description: Self-introspective analysis for session review and learning. Use when doing a retrospective, reviewing what we learned, reflecting on what went well or poorly in a session, or wrapping up a work session to capture learnings.
 ---
 
 # Retrospective

--- a/codery-docs/.codery/skills/codery-snr/SKILL.md
+++ b/codery-docs/.codery/skills/codery-snr/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Provide Summary, Next Steps, and Request next role. Use when the user needs orientation on current progress — checking where things stand, deciding what to do next, transitioning between tasks, or requesting a structured status update.
+description: Provide Summary, Next Steps, and Request next role. Use when summarizing progress, checking where we are, figuring out what's next, transitioning between tasks, or when the user asks for an SNR or status update on current work.
 ---
 
 # SNR

--- a/codery-docs/.codery/skills/codery-start/SKILL.md
+++ b/codery-docs/.codery/skills/codery-start/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Initialize the Codery system and start in Mirror Mode. Use at the beginning of a new work session when the user is ready to start working and the Codery role system needs to be activated.
+description: Initialize the Codery system and start in Mirror Mode. Use at the beginning of a new work session when starting work, initializing the system, or activating the Codery role workflow.
 ---
 
 # Start

--- a/codery-docs/.codery/skills/codery-status/SKILL.md
+++ b/codery-docs/.codery/skills/codery-status/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Understand the full context of a PR or JIRA ticket. Use when needing to gather context about a specific PR or JIRA ticket — checking progress, understanding where work stands, loading context before continuing on a ticket, or when a PR number or ticket ID is referenced and its status is relevant.
+description: Understand the full context of a PR or JIRA ticket. Use when checking the status of a PR, reading a ticket for context, checking where a PR or ticket stands, or when a PR number or ticket ID (like COD-XX) is referenced and needs investigation.
 argument-hint: <PR-number or ticket-id>
 ---
 


### PR DESCRIPTION
## Why

COD-43 replaced phrase-list triggers with context-aware descriptions, but went too far into abstraction. Skills stopped auto-invoking because Claude couldn't connect user input like "check PR 76" to descriptions like "gather context about a specific PR". The Claude Code docs explicitly state: "Check the description includes keywords users would naturally say."

## What

- Rewrote all 8 skill descriptions using a hybrid approach based on official Claude Code documentation
- Pattern: `[Capability]. Use when [active verb phrases using words users actually type]`
- Natural keywords woven into contextual situations — no quoted phrase lists, no abstract language
- Example: `"Use when checking the status of a PR, reading a ticket for context..."` instead of `"Use when needing to gather context about a specific PR"`

## How to verify

- Run `codery build` in a consumer project and test auto-invocation with natural phrases:
  - "check PR 76" should trigger codery-status
  - "review the PR" should trigger codery-audit
  - "what changed" should trigger codery-changelog
  - "retrospective" should trigger codery-retrospective

🤖 Generated with [Claude Code](https://claude.com/claude-code)