### PR TITLE
feat: tighten convention adherence (COD-51)

### DIFF
--- a/codery-docs/.codery/claude-md-template.md
+++ b/codery-docs/.codery/claude-md-template.md
@@ -19,6 +19,16 @@ You operate in **roles** — one at a time. Declare with icon + bold at the star
 
 ---
 
+## Before Starting a Task
+
+Before taking any action on a new task:
+
+1. **Check memory.** Review MEMORY.md for user preferences, prior feedback, and project context.
+2. **Check for a matching skill.** If a `codery-*` skill exists for the task, invoke it via the Skill tool rather than running raw commands.
+3. **Read ticket context.** If continuing on a JIRA ticket, read existing comments before commenting or acting.
+
+---
+
 ## Roles
 
 ### 🪞 Mirror — Reflect/confirm understanding

--- a/codery-docs/.codery/jira-reference.md
+++ b/codery-docs/.codery/jira-reference.md
@@ -72,3 +72,13 @@ Use role-specific comment prefixes: `[Scout]`, `[Architect]`, `[Builder]`, `[CRK
 - Issue types: Epic (`jira epic create`), Story/Task/Bug (`-tType`), Subtask (`-tSubtask -P`)
 - Flags: `--plain` (scripts), `--no-input` (automation), `--comments N` (view N comments)
 - Current user: `$(jira me)`
+
+## Anti-Patterns — Never Do These
+
+- **Heredocs for simple JIRA commands.** Use inline `-s "summary" -b "body"`. Heredocs slow the flow and are hard to edit mid-draft.
+- **Skipping `-p {{projectKey}}`.** Every `jira` command needs the project key — omitting it silently writes to the wrong project or errors.
+- **`--no-input` when the user should be prompted.** Only use it for commands with all values specified; never for interactive drafts.
+- **Creating or editing without the Preview & Approval step.** Show details and get approval first.
+- **Commenting without reading existing comments first.** Run `jira issue view KEY --comments 15` before adding to a ticket.
+- **Hardcoded issue keys in scripts.** Look up by name/summary with `-q` queries.
+- **Bypassing `codery-*` skills.** If a skill fits the task (codery-pr, codery-release, codery-audit, codery-snr, codery-status), invoke it via the Skill tool instead of raw commands.


### PR DESCRIPTION
## Why

The Q1 2026 Claude Code Insights report identified two recurring friction patterns that codified guidance would resolve: (1) Claude jumping into work without checking memory or available skills, forcing per-session correction; (2) Claude using inefficient or incorrect JIRA command patterns (heredocs, missing project-key flag, bypassing preview & approval) despite existing documentation. This PR adds two targeted guidance surfaces so the friction doesn't repeat.

Ticket: [COD-51](https://turalnovruzov.atlassian.net/browse/COD-51). Part of epic [COD-47](https://turalnovruzov.atlassian.net/browse/COD-47).

## What

- **`claude-md-template.md`** — new `## Before Starting a Task` section inserted between `## Core Rules` and `## Roles`. A three-step ritual: check memory, check for a matching `codery-*` skill, read JIRA ticket comments if continuing work.
- **`jira-reference.md`** — new `## Anti-Patterns — Never Do These` section appended after `## Key Points`. Seven bullets covering the specific missteps observed (heredocs for simple commands, skipping `-p`, misused `--no-input`, bypassing preview-and-approval, commenting without reading, hardcoded keys, bypassing `codery-*` skills).

Both new sections follow the section-naming convention already used by `codery-pr`'s own Anti-Patterns block, so the shape stays consistent across the system.

## How to Verify

- `codery build` in this repo emits the new `## Before Starting a Task` section in the generated `CLAUDE.md` (line 22) and the new `## Anti-Patterns` block in `.codery/refs/jira-reference.md` (line 76). Confirmed locally.
- `grep -n "Before Starting a Task\|Anti-Patterns" CLAUDE.md .codery/refs/jira-reference.md` returns the expected hits.
- Downstream projects pick up the new guidance on their next `codery update`.

## Reviewer Guidance

Commit type is `feat` (not `feat!`) — this is purely additive template content with no breaking change for downstream users. Semantic-release will cut a MINOR version (v8.0.0 → v8.1.0) on merge.