### PR TITLE
feat: enforce scout-first discipline (COD-48)

### DIFF
--- a/codery-docs/.codery/claude-md-template.md
+++ b/codery-docs/.codery/claude-md-template.md
@@ -16,6 +16,7 @@ You operate in **roles** — one at a time. Declare with icon + bold at the star
 - **JIRA**: Document substance in your own words. Every commit references ticket (`{{projectKey}}-XXX: Description`).
 - No mock data outside POC. No workarounds. No hardcoded IDs. No manufactured data.
 - You can downgrade roles freely. You must be asked to enter Builder, Patch, or Executor.
+- **Scout before proposing.** If you haven't read the code, docs, or ticket context that bears on the question, enter Scout Mode first. Don't guess the codebase.
 
 ---
 
@@ -35,7 +36,7 @@ Before taking any action on a new task:
 Repeats request in clear terms. Questions assumptions. Identifies missing information. Does NOT propose solutions or write code.
 
 ### 🧭 Scout — Research/explore
-Gathers information, investigates APIs, libraries, file structure. Presents findings summary to user. Does NOT modify code or commit to decisions.
+Reads files, greps code, examines APIs directly. Delegates to sub-agents only for broad codebase exploration that would take many queries; single-file reads and targeted greps stay inline. Presents findings to user. Does NOT modify code or commit to decisions.
 
 ### 🤔 Architect — Design/decide
 Weighs alternatives, pros/cons. Prepares technical recommendations. Documents THE ACTUAL DESIGN in JIRA (architecture, patterns, tradeoffs). Does NOT modify code.


### PR DESCRIPTION
## Why

The top Claude-side friction pattern in the Q1 2026 usage report was speculation before scouting — jumping to solutions without first reading the code, docs, or ticket context. Codery already has a Scout role in its lifecycle, but the template didn't name the anti-pattern or specify that scouting should be done directly rather than delegated to sub-agents. This PR codifies both.

Ticket: [COD-48](https://turalnovruzov.atlassian.net/browse/COD-48). Part of epic [COD-47](https://turalnovruzov.atlassian.net/browse/COD-47).

## What

- **Core Rules** — new bullet `Scout before proposing` names speculation-without-reading as an explicit anti-pattern. Paired with the existing `Start in Mirror Mode` rule, the guard now covers both session start and mid-task shifts.
- **Scout role description** — rewritten from the generic "gathers information, investigates APIs" to the direct "reads files, greps code, examines APIs directly" — with a concrete delegation threshold (sub-agents only for broad codebase exploration that would take many queries). This takes the "scout yourself" judgment out of the subjective bucket.

## How to Verify

- `codery build` in this repo emits the new Core Rules bullet at line 19 of the generated `CLAUDE.md` and the rewritten Scout role at line 39. Confirmed locally.
- `grep -n "Scout before proposing\|greps code" CLAUDE.md` returns both lines.
- Downstream projects pick up the new guidance on their next `codery update`.

## Reviewer Guidance

Commit type is `feat` — additive template change, no breaking behavior. Semantic-release will cut a MINOR version (v8.1.0 → v8.2.0) on merge.