### PR TITLE
feat: require verification evidence (COD-50)

### DIFF
--- a/codery-docs/.codery/claude-md-template.md
+++ b/codery-docs/.codery/claude-md-template.md
@@ -45,10 +45,10 @@ Weighs alternatives, pros/cons. Prepares technical recommendations. Documents TH
 Assesses confidence (0-100%), risks, and knowledge gaps before build. If below 85%, must present reasoning. Can recommend Builder or flag blockers.
 
 ### 🧰 Builder — Implement code
-Implements code based on vetted plans. Commits with `{{projectKey}}-XXX: Description`. Documents WHAT YOU BUILT in JIRA (conceptual explanation). Does NOT guess or use mock data.
+Implements code based on vetted plans. Commits with `{{projectKey}}-XXX: Description`. **Before handoff, states concrete verification evidence** (`ran X, observed Y`) — no handoff without it. Documents WHAT YOU BUILT in JIRA. Does NOT guess or use mock data.
 
 ### 🔧 Executor — Run/verify code
-Executes and verifies built code. Logs complications and completions in JIRA. Does NOT implement new code.
+Executes and verifies built code. Logs concrete evidence (`ran X, saw Y`) in JIRA for each verification step — complications, completions, test outputs. Does NOT implement new code.
 
 ### 🛠️ Patch — Fix specific bug
 Isolates and fixes a specific known issue. Minimal code diffs. Does NOT redesign or alter unrelated code.

--- a/codery-docs/.codery/skills/codery-pr/SKILL.md
+++ b/codery-docs/.codery/skills/codery-pr/SKILL.md
@@ -42,7 +42,7 @@ Examples:
 
 ### 4. Draft Description
 
-Every PR description has three mandatory sections, in this order.
+Every PR description has four mandatory sections, in this order.
 
 #### Why
 
@@ -52,6 +52,10 @@ Explain the problem or motivation. The description must stand on its own — lin
 
 Bulleted list of significant changes. Summarize intent, don't replay the diff. Keep it proportional — a one-line fix needs one bullet, not five. Review all commits on the branch, not just the latest.
 
+#### Evidence
+
+Concrete verification the author already performed before requesting review. Examples: `npm test passed`, `manually exercised the init flow in a sandbox project`, `grep -r 'xxx' returns only expected hits`. "I think it should work" is not evidence. If a section is genuinely N/A (e.g., documentation-only change with no code), say so explicitly.
+
 #### How to Verify
 
 Specific steps, commands, or test scenarios a reviewer can follow to validate the change. Automated test references count if they cover the claim.
@@ -59,7 +63,7 @@ Specific steps, commands, or test scenarios a reviewer can follow to validate th
 #### Conditional Sections (when applicable)
 
 - **Breaking Changes** — Migration steps, what breaks, who is affected. Never bury these inside the "What" list.
-- **Screenshots / Evidence** — Required for visual or UI changes. Before/after format preferred.
+- **Screenshots** — Required for visual or UI changes. Before/after format preferred.
 - **Reviewer Guidance** — Flag tricky decisions, areas needing extra attention, or related files the diff doesn't make obvious.
 
 ### 5. Sizing Check
@@ -84,6 +88,10 @@ gh pr create --title "the title" --body "$(cat <<'EOF'
 ...
 
 ## What
+
+- ...
+
+## Evidence
 
 - ...
 


### PR DESCRIPTION
## Why

The Q1 2026 usage report flagged premature "done" — Builder and Executor roles handing off without concrete evidence of verification, forcing per-session correction. The role descriptions invited it ("executes and verifies" without saying how evidence was recorded), and the codery-pr skill conflated author-performed verification with reviewer-facing steps. This PR adds explicit evidence requirements at both layers so "done" can't be claimed without proof.

Ticket: [COD-50](https://turalnovruzov.atlassian.net/browse/COD-50). Part of epic [COD-47](https://turalnovruzov.atlassian.net/browse/COD-47).

## What

- **Builder role** (`claude-md-template.md`) — adds "Before handoff, states concrete verification evidence (`ran X, observed Y`) — no handoff without it."
- **Executor role** (`claude-md-template.md`) — "Logs concrete evidence (`ran X, saw Y`) in JIRA for each verification step — complications, completions, test outputs."
- **codery-pr skill** (`SKILL.md`) — new mandatory `Evidence` section between `What` and `How to Verify`, capturing what the author already verified (distinct from reviewer steps). Also renames the conditional `Screenshots / Evidence` to just `Screenshots` to avoid overload, and updates the heredoc template.

## Evidence

- `node dist/bin/codery.js build --force` in this repo: produces updated `CLAUDE.md` (new Builder role at line 48, Executor at line 51) and updated codery-pr `SKILL.md` (Evidence section at line 55, heredoc block at line 94). Confirmed locally.
- **Dogfooded:** the codery-pr skill that guided this very PR already reflects the new structure — the "four mandatory sections" language and the Evidence section appeared in the skill output when I invoked it for this PR.
- \`git diff main...HEAD --stat\`: 2 files, +12/-4 — matches the described scope.

## How to Verify

- In a downstream consumer project: \`codery update\` → check that generated \`CLAUDE.md\` Builder and Executor role lines include the new evidence requirements.
- \`grep "concrete verification evidence" CLAUDE.md\` returns the Builder line; \`grep "Logs concrete evidence" CLAUDE.md\` returns the Executor line.

## Reviewer Guidance

Commit type is \`feat\` (not \`feat!\`) — additive with no behavior break for downstream users. Semantic-release will cut v8.2.0 → v8.3.0 on merge. The Evidence section is mandatory going forward; existing merged PRs don't need backfill.