### PR TITLE
feat(skills): rework codery-audit (COD-49)

### DIFF
--- a/codery-docs/.codery/skills/codery-audit/SKILL.md
+++ b/codery-docs/.codery/skills/codery-audit/SKILL.md
@@ -18,19 +18,38 @@ Perform a comprehensive PR review in the main conversation context for iterative
 ### 1. Requirements Compliance
 Extract requirements from JIRA ticket. Map each to implementation. Flag missing or partial implementations.
 
-### 2. Code Quality Review
+### 2. Pattern Comparison
+Find 1-3 prior merged PRs in the same area of the codebase (same feature surface, same framework area, same file type). Use `gh pr list` with relevant filters or `git log` on the target files. Diff the current PR's approach against what was done before:
+
+- Does it follow established naming, structure, and conventions?
+- Does it contradict recent decisions without explanation?
+- Does it introduce a new pattern that should be explicitly justified?
+
+If the PR diverges from prior patterns without explicit justification, flag it as a finding.
+
+### 3. Code Quality Review
 - **Security**: Authentication, authorization, data exposure, injection risks
 - **Performance**: Query efficiency, caching, resource management
 - **Quality**: Readability, naming, error handling, DRY principle
 - **Standards**: Project conventions from CLAUDE.md and application-docs
 - **Tests**: Coverage for new/modified code
 
-### 3. Present Findings
-Organize by severity: **Critical** (must fix) → **Recommendations** (should consider) → **Positive Notes** (good patterns).
+### 4. Present Findings (Private Draft)
+Organize by severity: **Critical** (must fix) → **Recommendations** (should consider) → **Positive Notes** (good patterns). This is a private draft in the conversation — not a GitHub post. Tone: direct, specific, sharp — for the user's review, not public consumption. Do NOT post to GitHub yet.
 
 ## Interactive Discussion
 
-After presenting findings, engage in discussion. Answer questions, clarify concerns, discuss alternatives, reach consensus.
+After presenting the private draft, engage in discussion. Answer questions, clarify concerns, discuss alternatives, reach consensus.
+
+## Posting to GitHub
+
+Only after the user explicitly approves posting (e.g., "post it", "submit", "ready"):
+
+1. **Inline comments by default.** Use `gh api` with the PR review-comment endpoints to attach per-line comments on the specific code locations. Reserve the top-level review body for a brief summary.
+2. **Softer public tone.** Phrase findings as questions or suggestions where appropriate ("Consider extracting..." vs "This should be extracted"). Keep critique specific; strip the private-draft sharpness.
+3. **Approval type.** APPROVE / REQUEST_CHANGES / COMMENT, chosen from finding severity.
+
+Never post without explicit approval. Never post the private draft verbatim.
 
 ## Final Report
 


### PR DESCRIPTION
## Why

codery-audit is the most-used skill in the Codery system (~18 sessions in Q1 2026 per the usage report), and it required per-session correction on four recurring dimensions: no pattern-comparison step, no explicit gate before posting reviews to GitHub, posting as single blobs instead of inline comments, and tone that was too sharp for public review bodies. This PR codifies all four behaviors in the skill itself so they don't need to be re-litigated each session.

Ticket: [COD-49](https://turalnovruzov.atlassian.net/browse/COD-49). Part of epic [COD-47](https://turalnovruzov.atlassian.net/browse/COD-47). This closes the epic.

## What

- **Pattern Comparison** — new Review Process step 2 requiring 1-3 prior merged PRs in the same area be diffed against the current PR (naming, structure, conventions). Divergences without justification become findings.
- **Draft-first** — step 4 renamed `Present Findings (Private Draft)` with explicit "do NOT post to GitHub yet." Private draft tone is direct and sharp.
- **Posting to GitHub** — new dedicated section after Interactive Discussion. Gated on explicit user approval. Inline per-line comments via \`gh api\` are the default; top-level review body is a brief summary only. Never post the private draft verbatim.
- **Tone calibration** — public posts soften to questions/suggestions; approval type (APPROVE / REQUEST_CHANGES / COMMENT) chosen from finding severity.

## Evidence

- \`node dist/bin/codery.js build --force\` regenerates \`.claude/skills/codery-audit/SKILL.md\` with the new sections at lines 21 (Pattern Comparison), 37 (Private Draft), 44 (Posting to GitHub), 48 (Inline comments by default). Confirmed locally.
- \`git diff main...HEAD --stat\`: 1 file, +23/-4 — matches the described rewrite scope.
- **Not dogfooded on a live PR review** — the session's PRs all merged before this change landed, so no open PR was available to exercise the new flow. Acceptance deferred to the next real PR review.

## How to Verify

- In a downstream consumer project: \`codery update\` → \`.claude/skills/codery-audit/SKILL.md\` shows the four new behaviors.
- \`grep "Pattern Comparison\|Private Draft\|Posting to GitHub" .claude/skills/codery-audit/SKILL.md\` returns the three new top-level sections.
- Run \`/codery-audit <pr-number>\` on a new PR and confirm: (a) it asks about prior PRs, (b) it presents findings in the conversation without touching GitHub, (c) it waits for explicit approval before posting, (d) when posting, it uses \`gh api\` for inline comments.

## Reviewer Guidance

Scope is a single-file rewrite; reading the full post-change \`SKILL.md\` is probably faster than diffing. Commit type is \`feat\` — additive guidance, no break for downstream users. Semantic-release will cut v8.3.0 → v8.4.0 on merge. This closes epic [COD-47](https://turalnovruzov.atlassian.net/browse/COD-47) (5/5 children upon merge).