### PR TITLE
feat(skills): add codery-autopilot (COD-54)

### DIFF
--- a/codery-docs/.codery/skills/codery-autopilot/SKILL.md
+++ b/codery-docs/.codery/skills/codery-autopilot/SKILL.md
@@ -1,0 +1,60 @@
+---
+description: Autopilot mode — autonomously take a ticket from interpretation to draft PR without per-step approval. Only run when the user explicitly invokes this skill with a JIRA ticket ID. Never auto-triggers.
+argument-hint: <ticket-id>
+disable-model-invocation: true
+---
+
+# Autopilot
+
+**Goal:** Take a JIRA ticket through the full Codery lifecycle — interpretation, design, implementation, verification, PR — without asking the user for approval at each step. The user's one intervention point is at the start (Mirror) and the end (reviewing the draft PR).
+
+**When to use:** Only when the user explicitly invokes this skill with a ticket ID. Never self-trigger.
+
+## The one gate: Mirror
+
+Before any autonomous action: read the ticket (delegate to `codery-status`), restate your understanding, list assumptions, and ask targeted clarifying questions. Wait for explicit user confirmation before starting the autonomous run.
+
+This is the only approval gate. If Mirror interpretation is wrong, the entire autonomous run is wasted — so this gate is non-negotiable.
+
+## Operating principles (autonomous run)
+
+After Mirror confirmation, run the lifecycle (Scout → Architect → CRK → Builder → Verify → PR) without pausing for approval. How you do each step is your judgment; the principles below shape it.
+
+**Delegation over re-implementation.** At each step, scan available skills for a matching one and use it. `codery-status` for ticket lookup, `codery-pr` for PR creation (as draft), project Figma or similar skills when context calls for them. Don't rewrite logic that already exists.
+
+**CRK is externally validated.** Self-grading is theater — the model that designed something can't fairly grade it. Before Builder, either call `advisor()` for a second opinion (preferred — sees full session), or spawn a subagent with an explicit payload (ticket, design, risks, intended diff) asking what's being overlooked. Act on flagged concerns rather than dismissing them.
+
+**JIRA is the accountability trail.** With no human watching, every meaningful transition must leave a trace — what you did, what you observed, what's next. Tag `[Autopilot]` for filterability. Pause comments must be specific enough that the user can unblock you without re-reading the whole trail.
+
+**Draft PR is the endpoint.** Never mark ready-for-review. Never merge. Human review of the draft is the final gate.
+
+**Branches are cheap.** New feature branch per run. On abort, leave it dirty for inspection — no cleanup, no reset.
+
+## Mechanical specifics (prescriptive)
+
+These don't need judgment — follow exactly:
+
+- Branch name: `feature/<ticket-id>-<slug>`
+- Commit format: conventional commits with ticket reference
+- PR state: draft (pass `--draft` to `codery-pr`, or use `gh pr create --draft` directly)
+
+## When to pause
+
+Hand back to the user when:
+
+- Mirror clarifications are unresolved.
+- CRK second opinion flags unresolved concerns, or unknowns remain listed.
+- Verification fails and you can't auto-diagnose (typos fine to fix; logic bugs need human).
+- Required credentials, deps, or context are missing.
+- A delegated skill returns a blocking error.
+
+On pause: log reason to JIRA, leave the branch, exit cleanly. Resume when the user unblocks you.
+
+## Anti-patterns
+
+- Starting the autonomous run without Mirror confirmation.
+- Re-implementing logic a sibling skill owns.
+- Marking the PR ready-for-review or merging it.
+- Passing CRK with unresolved unknowns.
+- Blind-retrying a verification failure.
+- Skeletal JIRA comments that don't explain what happened.

--- a/codery-docs/.codery/skills/codery-pr/SKILL.md
+++ b/codery-docs/.codery/skills/codery-pr/SKILL.md
@@ -1,7 +1,7 @@
 ---
 allowed-tools: Bash, Read, Grep
 description: Create a pull request with a well-structured description following industry best practices. Use when creating a PR, opening a pull request, pushing changes for review, or when the user says "create a PR", "open a PR", "make a pull request", or "ready for review".
-argument-hint: [ticket-id]
+argument-hint: [ticket-id] [--draft]
 ---
 
 # Create Pull Request
@@ -79,7 +79,7 @@ Show the user the drafted title and description. Wait for approval before creati
 After approval:
 
 1. Push the branch if not already pushed: `git push -u origin <branch>`
-2. Create the PR using `gh pr create` with a HEREDOC for the body:
+2. Create the PR using `gh pr create` with a HEREDOC for the body. If the invoker requested a draft PR (via `--draft` in arguments, or contextually — e.g., invoked by `codery-autopilot`), pass `--draft` to `gh pr create`:
 
 ```bash
 gh pr create --title "the title" --body "$(cat <<'EOF'


### PR DESCRIPTION
## Why

The Codery session improvements we shipped this month codified discipline for interactive sessions (scout-first, verification evidence, convention adherence). The next frontier from the Q1 2026 usage report was **autonomous ticket execution** — taking a well-scoped ticket from interpretation to draft PR without per-step approvals. This PR introduces an opt-in skill that runs the full lifecycle autonomously while preserving a human gate at the critical start (Mirror interpretation) and end (draft PR review).

Ticket: [COD-54](https://turalnovruzov.atlassian.net/browse/COD-54).

## What

- **New \`codery-autopilot\` skill** (\`codery-docs/.codery/skills/codery-autopilot/SKILL.md\`). Mirror is the only approval gate. After user confirmation, the autonomous run delegates to sibling skills (\`codery-status\`, \`codery-pr\`, etc.) rather than re-implementing logic. CRK is externally validated via \`advisor()\` or a subagent payload — self-grading is disallowed. JIRA receives an \`[Autopilot]\` trail at every transition. Endpoint is a draft PR; never marks ready-for-review, never merges.
- **\`codery-pr\` update.** \`argument-hint\` accepts optional \`--draft\` flag; step 7 explains draft handling so invoking skills (including autopilot) can request a draft PR via \`gh pr create --draft\`.
- **Authored principle-first** per the recent feedback memory. Goals, signals, tools — with mechanical prescriptions only where no judgment is needed (branch name, commit format, draft state).

## Evidence

- \`node dist/bin/codery.js build --force\` produces \`.claude/skills/codery-autopilot/SKILL.md\` and the updated \`.claude/skills/codery-pr/SKILL.md\` (argument-hint and step 7 draft note). Confirmed locally.
- \`disable-model-invocation: true\` is set on the autopilot skill so the model-invocation path won't auto-fire; the user must explicitly invoke.
- **Not end-to-end dogfooded on a real ticket yet** — acceptance criteria require this validation, deferred to the first autopilot run after merge.

## How to Verify

- In a downstream project: \`codery update\` → \`.claude/skills/codery-autopilot/SKILL.md\` lands with the principle-driven structure.
- \`/codery-autopilot COD-XX\` on a test ticket should: (a) delegate to \`codery-status\` for ticket lookup, (b) restate the ticket and ask clarifying questions, (c) wait for explicit confirmation, (d) only after confirmation begin the autonomous Scout → Architect → CRK → Builder → Verify → PR run, (e) log \`[Autopilot]\` comments to JIRA at each transition, (f) delegate to \`codery-pr\` with \`--draft\` when creating the PR.
- Deliberately-ambiguous ticket: autopilot should pause at Mirror and ask rather than guess.
- Ticket that breaks CRK (missing dep, etc.): autopilot should catch it in CRK and pause.

## Reviewer Guidance

Commit type is \`feat\` — new capability, no breaking change. Semantic-release will cut v8.4.0 → v8.5.0 on merge. This is the first skill authored under the new principle-driven authorship memory; structure is intentionally goal/signal/tool oriented. Rigid numbered recipes are avoided except for truly mechanical steps. Real validation comes from running autopilot on a small ticket — that's called out in acceptance criteria.