### PR TITLE
feat(skills): reorder codery-release Step 8 to PR-first workflow (COD-56)

### DIFF
--- a/codery-docs/.codery/GitWorkflows/GitFlow.md
+++ b/codery-docs/.codery/GitWorkflows/GitFlow.md
@@ -33,9 +33,10 @@ git push origin feature/{{projectKey}}-123-description
 # Release
 git checkout {{developBranch}} && git pull origin {{developBranch}}
 git checkout -b release/X.Y.Z
-# Test, fix, commit: "chore: prepare release X.Y.Z"
-# Create PRs to both {{mainBranch}} and {{developBranch}}
-# Tag on {{mainBranch}}: git tag vX.Y.Z && git push origin vX.Y.Z
+git push -u origin release/X.Y.Z
+# Open PR to {{mainBranch}}, test on preview (or locally), fix on branch as needed
+# After approval, merge PR, then tag on {{mainBranch}}: git tag vX.Y.Z && git push origin vX.Y.Z
+# Back-merge: gh pr create --base {{developBranch}} (sync-only, no QA)
 
 # Hotfix
 git checkout {{mainBranch}} && git pull origin {{mainBranch}}

--- a/codery-docs/.codery/GitWorkflows/GitFlow.md
+++ b/codery-docs/.codery/GitWorkflows/GitFlow.md
@@ -34,9 +34,12 @@ git push origin feature/{{projectKey}}-123-description
 git checkout {{developBranch}} && git pull origin {{developBranch}}
 git checkout -b release/X.Y.Z
 git push -u origin release/X.Y.Z
-# Open PR to {{mainBranch}}, test on preview (or locally), fix on branch as needed
-# After approval, merge PR, then tag on {{mainBranch}}: git tag vX.Y.Z && git push origin vX.Y.Z
-# Back-merge: gh pr create --base {{developBranch}} (sync-only, no QA)
+# Open BOTH PRs up front: release → {{mainBranch}} (QA) + release → {{developBranch}} (sync)
+# Opening both keeps the release branch alive across the first merge when auto-delete is on
+# gh pr create --base {{developBranch}}   # the back-merge PR
+# Test on the main PR's preview (or locally), push fixes to the release branch as needed
+# On approval: merge main PR → tag {{mainBranch}} → merge back-merge PR
+# Tag: git tag vX.Y.Z && git push origin vX.Y.Z
 
 # Hotfix
 git checkout {{mainBranch}} && git pull origin {{mainBranch}}

--- a/codery-docs/.codery/skills/codery-release/SKILL.md
+++ b/codery-docs/.codery/skills/codery-release/SKILL.md
@@ -118,9 +118,12 @@ Wait for user approval on the version before creating the branch.
 git checkout -b release/X.Y.Z
 ```
 
-### 8. Open PR, Ship, and Sync
+### 8. Open PRs, Ship, and Sync
 
-Open the release PR to `{{mainBranch}}` *first* so CI runs and — if the project has preview deploys — QA can happen on the preview URL. Don't gate PR creation on local testing; let the PR be where testing happens. The back-merge to `{{developBranch}}` is a separate, later step (sync-only, no QA).
+Open *both* PRs (release → `{{mainBranch}}` and release → `{{developBranch}}`) before merging either. Reasons:
+
+- **PR-first QA.** The release PR to `{{mainBranch}}` triggers CI and — if the project has preview deploys — gives QA a preview URL. Don't gate PR creation on local testing.
+- **Branch preservation.** Many repos enable "Automatically delete head branches." GitHub skips auto-delete while any open PR still references the branch, so opening both PRs up front keeps `release/X.Y.Z` alive across the first merge. Open the `{{mainBranch}}` PR only, merge it, and the branch is gone before you can open the back-merge.
 
 1. Push: `git push -u origin release/X.Y.Z`
 
@@ -128,18 +131,22 @@ Open the release PR to `{{mainBranch}}` *first* so CI runs and — if the projec
    - Use the commit/PR/JIRA context gathered in Step 4 for the description (Why / What / How to Verify), consistent with `codery-pr` output.
    - Open as a normal PR, **not draft**. A release branch means "we think this is shippable, please review"; draft would delay required reviewers and preview-deploy notifications.
 
-3. **Test the release** on the preview deploy attached to the PR. If the project has no preview deploy, fall back to a local checkout of `release/X.Y.Z`. Push fixes to the release branch as issues surface — the PR updates automatically.
+3. **Open the back-merge PR** immediately with `gh pr create --base {{developBranch}}` (codery-pr assumes `{{mainBranch}}` as the base and isn't suitable here). Title it so reviewers know it's a sync — e.g. `chore: back-merge release X.Y.Z to {{developBranch}}`. Body can point to the release PR for context.
 
-4. **On approval, merge the release PR, then tag:**
+4. **Test the release** on the preview deploy attached to the `{{mainBranch}}` PR. If the project has no preview deploy, fall back to a local checkout of `release/X.Y.Z`. Push fixes to the release branch as issues surface — *both* PRs update automatically.
+
+5. **On approval, merge the release PR, then tag:**
 
    ```bash
    git checkout {{mainBranch}} && git pull
    git tag vX.Y.Z && git push origin vX.Y.Z
    ```
 
-5. **Open the back-merge PR** from `release/X.Y.Z` to `{{developBranch}}` with `gh pr create --base {{developBranch}}` (codery-pr assumes `{{mainBranch}}` as the base and isn't suitable here). Merge promptly — this is a sync, not a QA step.
+   The release branch stays alive here because the back-merge PR still references it.
 
-6. Emit a **draft release-notes block** for the eventual GitHub release, using the default structure below. The skill should fill in the entries from the gathered commits, PRs, and parent tickets — citing the **parent Story or Task** (not subtasks) so the notes read as user-visible outcomes rather than implementation fragments. Omit sections that have no entries.
+6. **Merge the back-merge PR.** The release branch auto-deletes on this merge (if that's enabled in the repo). If the back-merge PR went red after step 5 (rare in a release flow, but possible if `{{mainBranch}}` had diverged), resolve conflicts on the release branch and push — GitHub re-runs mergeability.
+
+7. Emit a **draft release-notes block** for the eventual GitHub release, using the default structure below. The skill should fill in the entries from the gathered commits, PRs, and parent tickets — citing the **parent Story or Task** (not subtasks) so the notes read as user-visible outcomes rather than implementation fragments. Omit sections that have no entries.
 
    ```markdown
    ## Breaking changes

--- a/codery-docs/.codery/skills/codery-release/SKILL.md
+++ b/codery-docs/.codery/skills/codery-release/SKILL.md
@@ -118,15 +118,28 @@ Wait for user approval on the version before creating the branch.
 git checkout -b release/X.Y.Z
 ```
 
-### 8. Push and Guide
+### 8. Open PR, Ship, and Sync
+
+Open the release PR to `{{mainBranch}}` *first* so CI runs and — if the project has preview deploys — QA can happen on the preview URL. Don't gate PR creation on local testing; let the PR be where testing happens. The back-merge to `{{developBranch}}` is a separate, later step (sync-only, no QA).
 
 1. Push: `git push -u origin release/X.Y.Z`
-2. Remind the user to:
-   - Test the release branch
-   - Create PRs to both `{{mainBranch}}` and `{{developBranch}}`
-   - Tag on `{{mainBranch}}` after merge: `git tag vX.Y.Z && git push origin vX.Y.Z`
-3. Suggest using the gathered commit/PR/JIRA context to write the release PR description (Why/What/How to Verify) — consistent with `codery-pr` skill output.
-4. Emit a **draft release-notes block** for the eventual GitHub release, using the default structure below. The skill should fill in the entries from the gathered commits, PRs, and parent tickets — citing the **parent Story or Task** (not subtasks) so the notes read as user-visible outcomes rather than implementation fragments. Omit sections that have no entries.
+
+2. **Open the release PR** to `{{mainBranch}}` via `codery-pr` (or `gh pr create` directly). This is the QA-bearing PR — merging it ships the release.
+   - Use the commit/PR/JIRA context gathered in Step 4 for the description (Why / What / How to Verify), consistent with `codery-pr` output.
+   - Open as a normal PR, **not draft**. A release branch means "we think this is shippable, please review"; draft would delay required reviewers and preview-deploy notifications.
+
+3. **Test the release** on the preview deploy attached to the PR. If the project has no preview deploy, fall back to a local checkout of `release/X.Y.Z`. Push fixes to the release branch as issues surface — the PR updates automatically.
+
+4. **On approval, merge the release PR, then tag:**
+
+   ```bash
+   git checkout {{mainBranch}} && git pull
+   git tag vX.Y.Z && git push origin vX.Y.Z
+   ```
+
+5. **Open the back-merge PR** from `release/X.Y.Z` to `{{developBranch}}` with `gh pr create --base {{developBranch}}` (codery-pr assumes `{{mainBranch}}` as the base and isn't suitable here). Merge promptly — this is a sync, not a QA step.
+
+6. Emit a **draft release-notes block** for the eventual GitHub release, using the default structure below. The skill should fill in the entries from the gathered commits, PRs, and parent tickets — citing the **parent Story or Task** (not subtasks) so the notes read as user-visible outcomes rather than implementation fragments. Omit sections that have no entries.
 
    ```markdown
    ## Breaking changes


### PR DESCRIPTION
## Why

The codery-release skill's Step 8 previously told users to test the release branch locally *before* opening any PR. That ordering predates per-PR preview deployments and PR-gated CI: in modern setups (Vercel/Netlify/Amplify) the PR is what triggers the preview build and the full CI pipeline, so meaningful QA can't happen before the PR exists. The old flow left users in a backwards state — asked to test something they couldn't properly test yet.

## What

- Rewrote Step 8 of `codery-release` to open the release PR to `main` **first**, then test on the preview deploy (or local fallback), merge, tag, and finally back-merge to `develop`.
- Called out the two-PR asymmetry explicitly: the `main` PR is the QA-bearing one; the `develop` back-merge is sync-only with no QA step.
- Specified `gh pr create --base {{developBranch}}` for the back-merge (advisor-flagged: `codery-pr` hardcodes `main` as base and isn't suitable here).
- Renamed the step heading from "Push and Guide" → "Open PR, Ship, and Sync".
- Updated `GitFlow.md` release section for consistency (scope-expansion beyond the original ticket — hotfix section left alone, different dynamics, follow-up).

## Evidence

- `npm run build` → clean
- `npm run typecheck` → clean
- `node ./dist/bin/codery.js build --force` → skills regenerated; verified generated `.claude/skills/codery-release/SKILL.md` Step 8 matches source after `{{mainBranch}}`→`main` substitution
- Grep for stale language (`"Test the release branch"`, `"Create PRs to both"`) across `codery-docs/`, `docs/`, `engineering-docs/`, `README.md` → only hits are the files updated in this PR

## How to Verify

1. Read `codery-docs/.codery/skills/codery-release/SKILL.md` lines 121–158 — confirm PR-first ordering, explicit non-draft rationale, and two-PR asymmetry callout.
2. Run `node ./dist/bin/codery.js build --force` and open `.claude/skills/codery-release/SKILL.md` to confirm template substitution works.
3. Mentally step through the flow on a Git-Flow repo with preview deploys (e.g. a frontend) — confirm the sequence lines up with Vercel/Netlify trigger semantics.

## Reviewer Guidance

- **Pre-existing warning not introduced by this change:** building `codery-release` for a trunk-based project (like codery itself) emits `⚠️  Unsubstituted in codery-release: developBranch`. The release skill is Git-Flow-only by design; the warning existed before this change (5 `{{developBranch}}` refs before, 6 after). Separate concern — open a follow-up if you want that suppressed.
- **Draft PR because autopilot opened it.** Autopilot's gating rule is never-mark-ready; merging is the reviewer's call.

Ticket: [COD-56](https://turalnovruzov.atlassian.net/browse/COD-56)