### PR TITLE
feat(jira): reintroduce Atlassian MCP integration (COD-57)

### DIFF
--- a/codery-docs/.codery/jira-reference-cli.md
+++ b/codery-docs/.codery/jira-reference-cli.md
@@ -1,14 +1,10 @@
-# JIRA Reference
+# JIRA Reference (CLI)
 
 **Project Key**: `{{projectKey}}`
 
-## Workflow States
-
-1. **To Do** → **In Progress** → **In Review** → **Done**
-
 ## Preview & Approval
 
-Before any JIRA ticket create or edit: display details to user, ask for approval, then proceed.
+Before creating a ticket, editing a ticket, or adding a comment: display details to user, ask for approval, then proceed. Transitions and worklog additions proceed without approval — they're core workflow, not content creation.
 
 ## Git Branch Naming
 
@@ -78,7 +74,7 @@ Use role-specific comment prefixes: `[Scout]`, `[Architect]`, `[Builder]`, `[CRK
 - **Heredocs for simple JIRA commands.** Use inline `-s "summary" -b "body"`. Heredocs slow the flow and are hard to edit mid-draft.
 - **Skipping `-p {{projectKey}}`.** Every `jira` command needs the project key — omitting it silently writes to the wrong project or errors.
 - **`--no-input` when the user should be prompted.** Only use it for commands with all values specified; never for interactive drafts.
-- **Creating or editing without the Preview & Approval step.** Show details and get approval first.
+- **Creating, editing, or commenting without the Preview & Approval step.** Show details and get approval first. (Transitions and worklogs are exempt.)
 - **Commenting without reading existing comments first.** Run `jira issue view KEY --comments 15` before adding to a ticket.
 - **Hardcoded issue keys in scripts.** Look up by name/summary with `-q` queries.
 - **Bypassing `codery-*` skills.** If a skill fits the task (codery-pr, codery-release, codery-audit, codery-snr, codery-status), invoke it via the Skill tool instead of raw commands.

--- a/codery-docs/.codery/jira-reference-cli.md
+++ b/codery-docs/.codery/jira-reference-cli.md
@@ -4,7 +4,18 @@
 
 ## Preview & Approval
 
-Before creating a ticket, editing a ticket, or adding a comment: display details to user, ask for approval, then proceed. Transitions and worklog additions proceed without approval — they're core workflow, not content creation.
+Display and get approval before:
+- Creating a ticket
+- Editing a ticket
+- Commenting on a ticket **other** than the one you're actively working (parent story, sibling subtask, linked ticket)
+- Commenting in a way that addresses other people (@mentions, questions for the team, decisions you want to broadcast)
+
+Proceed without approval for:
+- Status transitions
+- Worklog additions
+- Tracking and progress comments on the ticket you're actively working (the role-prefixed `[Scout]`, `[Builder]`, etc. lifecycle notes — these exist for your own audit trail)
+
+The distinguishing signal is audience: if other people will read it, get approval; if it's just you documenting your own work, don't slow the loop.
 
 ## Git Branch Naming
 
@@ -74,7 +85,7 @@ Use role-specific comment prefixes: `[Scout]`, `[Architect]`, `[Builder]`, `[CRK
 - **Heredocs for simple JIRA commands.** Use inline `-s "summary" -b "body"`. Heredocs slow the flow and are hard to edit mid-draft.
 - **Skipping `-p {{projectKey}}`.** Every `jira` command needs the project key — omitting it silently writes to the wrong project or errors.
 - **`--no-input` when the user should be prompted.** Only use it for commands with all values specified; never for interactive drafts.
-- **Creating, editing, or commenting without the Preview & Approval step.** Show details and get approval first. (Transitions and worklogs are exempt.)
+- **Skipping Preview & Approval for cross-ticket or audience-facing actions.** See the Preview & Approval section above for the audience test — tracking comments on the active ticket and status transitions are exempt.
 - **Commenting without reading existing comments first.** Run `jira issue view KEY --comments 15` before adding to a ticket.
 - **Hardcoded issue keys in scripts.** Look up by name/summary with `-q` queries.
 - **Bypassing `codery-*` skills.** If a skill fits the task (codery-pr, codery-release, codery-audit, codery-snr, codery-status), invoke it via the Skill tool instead of raw commands.

--- a/codery-docs/.codery/jira-reference-mcp.md
+++ b/codery-docs/.codery/jira-reference-mcp.md
@@ -7,7 +7,18 @@ Pass the site hostname (or UUID) above as `cloudId` to MCP tools. The Atlassian 
 
 ## Preview & Approval
 
-Before creating a ticket, editing a ticket, or adding a comment: display the intended content to the user, ask for approval, then proceed. Transitions and worklog additions proceed without approval — they're core workflow, not content creation.
+Display and get approval before:
+- Creating a ticket
+- Editing a ticket
+- Commenting on a ticket **other** than the one you're actively working (parent story, sibling subtask, linked ticket)
+- Commenting in a way that addresses other people (@mentions, questions for the team, decisions you want to broadcast)
+
+Proceed without approval for:
+- Status transitions
+- Worklog additions
+- Tracking and progress comments on the ticket you're actively working (the role-prefixed `[Scout]`, `[Builder]`, etc. lifecycle notes — these exist for your own audit trail)
+
+The distinguishing signal is audience: if other people will read it, get approval; if it's just you documenting your own work, don't slow the loop.
 
 ## Progress Tracking
 
@@ -21,7 +32,7 @@ Use role-specific comment prefixes: `[Scout]`, `[Architect]`, `[Builder]`, `[CRK
 
 ## Anti-Patterns — Never Do These
 
-- **Creating, editing, or commenting without the Preview & Approval step.** Show details and get approval first. (Transitions and worklogs are exempt.)
+- **Skipping Preview & Approval for cross-ticket or audience-facing actions.** See the Preview & Approval section above for the audience test — tracking comments on the active ticket and status transitions are exempt.
 - **Commenting without reading existing comments first.** Fetch the issue with recent comments before adding yours.
 - **Hardcoded issue keys in scripts or assumptions.** Look up by summary/properties via JQL search.
 - **Bypassing `codery-*` skills.** If a skill fits the task (codery-pr, codery-release, codery-audit, codery-snr, codery-status), invoke it via the Skill tool instead of forming JIRA calls directly.

--- a/codery-docs/.codery/jira-reference-mcp.md
+++ b/codery-docs/.codery/jira-reference-mcp.md
@@ -1,0 +1,27 @@
+# JIRA Reference (Atlassian MCP)
+
+**Project Key**: `{{projectKey}}`
+**Site / Cloud ID**: `{{jiraCloudId}}`
+
+Pass the site hostname (or UUID) above as `cloudId` to MCP tools. The Atlassian MCP exposes tools for reading issues/comments, searching JQL, creating/editing issues, transitioning status, and adding worklogs — tool schemas are self-describing, so no command syntax is documented here.
+
+## Preview & Approval
+
+Before creating a ticket, editing a ticket, or adding a comment: display the intended content to the user, ask for approval, then proceed. Transitions and worklog additions proceed without approval — they're core workflow, not content creation.
+
+## Progress Tracking
+
+Use role-specific comment prefixes: `[Scout]`, `[Architect]`, `[Builder]`, `[CRK]`. Always read existing comments on a ticket before adding a new one.
+
+## Git Branch Naming
+
+- Feature: `feature/{{projectKey}}-123-description`
+- Bugfix: `bugfix/{{projectKey}}-456-description`
+- Hotfix: `hotfix/{{projectKey}}-789-description`
+
+## Anti-Patterns — Never Do These
+
+- **Creating, editing, or commenting without the Preview & Approval step.** Show details and get approval first. (Transitions and worklogs are exempt.)
+- **Commenting without reading existing comments first.** Fetch the issue with recent comments before adding yours.
+- **Hardcoded issue keys in scripts or assumptions.** Look up by summary/properties via JQL search.
+- **Bypassing `codery-*` skills.** If a skill fits the task (codery-pr, codery-release, codery-audit, codery-snr, codery-status), invoke it via the Skill tool instead of forming JIRA calls directly.

--- a/codery-docs/.codery/skills/codery-release/SKILL.md
+++ b/codery-docs/.codery/skills/codery-release/SKILL.md
@@ -73,11 +73,9 @@ PR bodies often capture *why* and *breaking notes* that commits don't. Cross-che
 - Multiple subtasks rolling up to the same parent — often a coordinated feature
 - Any Epic Link or `parent` field present in the ticket
 
-**Tools.**
+**What to fetch.** For each ticket, capture summary, issue type, priority, status, any breaking-change labels, and the parent ticket key (subtasks usually expose it under `fields.parent`; epic links often live in a project-specific custom field).
 
-- `jira issue view <KEY> -p {{projectKey}} --plain` — human-readable summary. Use for capturing summary, issue type, priority, status, and breaking-change labels.
-- `jira issue view <KEY> -p {{projectKey}} --raw | jq '.fields.parent'` — extracts the parent ticket key. `--plain` output omits parent and epic-link fields; `--raw` is required when you need the relationship graph.
-- `jq '.fields | to_entries[] | select(.value.key? != null)'` on the raw output — locates Epic Link (often a custom field with a project-specific ID).
+Use whichever JIRA integration this project is configured for — see `.codery/refs/jira-reference.md`. Parent and epic-link fields are often omitted from default ticket views; request them explicitly when walking relationships (e.g. pass `--raw` to the JIRA CLI, or specify `fields: ["parent", ...]` on an MCP issue fetch).
 
 **Default behavior.**
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -46,6 +46,20 @@ Codery stores configuration in `.codery/config.json`.
 - **Used in**: Determines which workflow file is included in CLAUDE.md
 - **Note**: When using trunk-based, `developBranch` is not needed
 
+### jiraIntegrationType
+- **Type**: String
+- **Optional**: Yes (default: `"cli"`)
+- **Description**: Selects how Claude interacts with JIRA
+- **Options**: `"cli"` (requires `jira` CLI + API token) or `"mcp"` (requires the Atlassian MCP server installed in Claude Code)
+- **Used in**: Determines which JIRA reference file is emitted to `.codery/refs/jira-reference.md`
+
+### jiraCloudId
+- **Type**: String
+- **Optional**: Yes (required when `jiraIntegrationType` is `"mcp"`)
+- **Description**: Your Atlassian site — the MCP passes this as `cloudId` on every tool call
+- **Example**: `"company.atlassian.net"`
+- **Note**: Either the site hostname (recommended, human-readable) or the UUID works
+
 ## Example Configurations
 
 ### Basic Configuration
@@ -99,6 +113,17 @@ Codery stores configuration in `.codery/config.json`.
 }
 ```
 
+### Atlassian MCP Integration
+```json
+{
+  "projectKey": "ACME",
+  "mainBranch": "main",
+  "gitWorkflowType": "trunk-based",
+  "jiraIntegrationType": "mcp",
+  "jiraCloudId": "company.atlassian.net"
+}
+```
+
 ### Full Configuration Example
 ```json
 {
@@ -123,6 +148,7 @@ When you run `codery build`, these values replace template variables throughout 
 | `{{projectKey}}` | Your projectKey value | `ACME` |
 | `{{developBranch}}` | Your developBranch value | `develop` |
 | `{{mainBranch}}` | Your mainBranch value | `main` |
+| `{{jiraCloudId}}` | Your jiraCloudId value (MCP only) | `company.atlassian.net` |
 
 ### Example Transformation
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -31,6 +31,7 @@ codery init
 This will prompt you to:
 - Select your Git workflow (Git Flow or Trunk-Based)
 - Configure your project key and branch names
+- Choose how Claude interacts with JIRA: the `jira` CLI (with API token) or the Atlassian MCP server
 
 The command creates `.codery/config.json` with your chosen configuration.
 

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -20,6 +20,7 @@ Codery uses a template variable system to customize documentation for your speci
 | `{{projectKey}}` | JIRA project identifier | `projectKey` | (required) |
 | `{{developBranch}}` | Development branch name | `developBranch` | `"develop"` |
 | `{{mainBranch}}` | Production branch name | `mainBranch` | `"main"` |
+| `{{jiraCloudId}}` | Atlassian site hostname (MCP only) | `jiraCloudId` | (required when `jiraIntegrationType` is `"mcp"`) |
 
 ## Template Substitution Process
 

--- a/engineering-docs/README.md
+++ b/engineering-docs/README.md
@@ -87,6 +87,14 @@ Codery follows the npm principle: **track inputs, ignore outputs**.
 
 ## Version History
 
+### Version 8.x - Atlassian MCP Reintroduction (COD-57)
+- Reintroduced the Atlassian MCP as an opt-in JIRA integration alongside the CLI (removed in v8.0.0)
+- Config regains `jiraIntegrationType: 'mcp' | 'cli'` (default `cli` for backward compat) and `jiraCloudId`
+- Template split: `jira-reference-cli.md` (existing command-oriented ref) and new slim `jira-reference-mcp.md` (tool-schema-driven)
+- Hardcoded workflow states removed from both reference files — projects define their own
+- Preview & approval convention relaxed: applies only to ticket create/edit/comment; transitions and worklogs are exempt
+- `codery-release` skill rewritten to be integration-agnostic (no hardcoded `jira` CLI syntax)
+
 ### Version 7.0.0 - Modernization (COD-41) — Breaking
 - **CLAUDE.md**: ~800 lines → ~85 lines using `@` imports for reference docs
 - **Commands → Skills**: 8 commands migrated from `.claude/commands/` to `.claude/skills/` format
@@ -193,7 +201,7 @@ codery-docs/.codery/claude-md-template.md
     │
     ▼
 CLAUDE.md (with @imports that Claude Code resolves at runtime)
-    ├── @.codery/refs/jira-reference.md  ← copied from jira-reference.md
+    ├── @.codery/refs/jira-reference.md  ← copied from jira-reference-{cli,mcp}.md
     ├── @.codery/refs/git-workflow.md    ← copied from GitWorkflows/{GitFlow,TrunkBased}.md
     └── @engineering-docs/*.md           ← user's own docs (not copied, referenced in-place)
 
@@ -205,13 +213,19 @@ CLAUDE.md (with @imports that Claude Code resolves at runtime)
 **Config Structure** (`CoderyConfig` interface):
 ```typescript
 {
-  projectKey: string;         // JIRA project key
-  developBranch?: string;     // For Git Flow
-  mainBranch?: string;        // Main branch name
-  applicationDocs?: string[]; // Paths to project-specific docs (become @imports)
+  projectKey: string;                          // JIRA project key
+  developBranch?: string;                      // For Git Flow
+  mainBranch?: string;                         // Main branch name
+  applicationDocs?: string[];                  // Paths to project-specific docs (become @imports)
   gitWorkflowType?: 'gitflow' | 'trunk-based';
+  jiraIntegrationType?: 'mcp' | 'cli';         // Default 'cli'
+  jiraCloudId?: string;                        // Required when jiraIntegrationType === 'mcp'
 }
 ```
+
+**JIRA integration** is selected at `codery init` time:
+- `cli` (default): emits `jira-reference-cli.md` → `.codery/refs/jira-reference.md`. Requires the `jira` CLI installed locally with an API token.
+- `mcp`: emits the slim `jira-reference-mcp.md`. Requires the Atlassian MCP server installed in Claude Code. The `jiraCloudId` (e.g. `company.atlassian.net`) is passed through to the reference file as `{{jiraCloudId}}` and then used as the `cloudId` argument to MCP tool calls.
 
 **Storage**: `.codery/config.json` (tracked in git)
 

--- a/src/lib/buildDocs.ts
+++ b/src/lib/buildDocs.ts
@@ -85,6 +85,16 @@ function getGitWorkflowSource(config: CoderyConfig | null): string {
   return fileMap[workflowType];
 }
 
+// Get the appropriate JIRA reference source file based on config
+function getJiraReferenceSource(config: CoderyConfig | null): string {
+  const integrationType = config?.jiraIntegrationType || 'cli';
+  const fileMap: Record<string, string> = {
+    'cli': 'jira-reference-cli.md',
+    'mcp': 'jira-reference-mcp.md'
+  };
+  return fileMap[integrationType];
+}
+
 // Copy reference files to .codery/ directory with substitution
 function copyReferenceFiles(
   config: CoderyConfig | null,
@@ -100,8 +110,9 @@ function copyReferenceFiles(
       fs.mkdirSync(coderyDir, { recursive: true });
     }
 
-    // Copy JIRA reference
-    const jiraSource = path.join(sourceDir, 'jira-reference.md');
+    // Copy JIRA reference (CLI or MCP variant based on config)
+    const jiraSourceFile = getJiraReferenceSource(config);
+    const jiraSource = path.join(sourceDir, jiraSourceFile);
     const refsDir = path.join(coderyDir, 'refs');
     if (!fs.existsSync(refsDir)) {
       fs.mkdirSync(refsDir, { recursive: true });
@@ -111,7 +122,7 @@ function copyReferenceFiles(
 
     if (fs.existsSync(jiraSource)) {
       if (dryRun) {
-        log(`Would copy jira-reference.md → .codery/jira-reference.md`);
+        log(`Would copy ${jiraSourceFile} → .codery/jira-reference.md`);
       } else {
         let content = fs.readFileSync(jiraSource, 'utf-8');
         if (config) {

--- a/src/lib/initCommand.ts
+++ b/src/lib/initCommand.ts
@@ -126,7 +126,8 @@ export async function initCommand(options: InitOptions): Promise<void> {
     ]);
 
     // Build config object — preserve existing fields and merge with new answers.
-    // Strip the legacy pre-v5 `cloudId` field name; we use `jiraCloudId` now.
+    // Strip the legacy v5–v7 `cloudId` field name (removed in v8.0.0). The
+    // current field is `jiraCloudId` and stores a hostname, not a full URL.
     const { cloudId: _legacyCloudId, ...preservedConfig } =
       existingConfig as CoderyConfig & { cloudId?: string };
     const config: CoderyConfig = {

--- a/src/lib/initCommand.ts
+++ b/src/lib/initCommand.ts
@@ -62,6 +62,8 @@ export async function initCommand(options: InitOptions): Promise<void> {
     console.log('Let\'s configure your project:');
     console.log();
 
+    const legacyCloudId = (existingConfig as CoderyConfig & { cloudId?: string }).cloudId;
+
     const answers = await inquirer.prompt([
       {
         type: 'list',
@@ -86,6 +88,29 @@ export async function initCommand(options: InitOptions): Promise<void> {
         }
       },
       {
+        type: 'list',
+        name: 'jiraIntegrationType',
+        message: 'How will Claude interact with JIRA?',
+        choices: [
+          { name: 'JIRA CLI (requires `jira` CLI installed with an API token)', value: 'cli' },
+          { name: 'Atlassian MCP (configure an MCP server in Claude Code)', value: 'mcp' }
+        ],
+        default: currentValues.jiraIntegrationType || 'cli'
+      },
+      {
+        type: 'input',
+        name: 'jiraCloudId',
+        message: 'Atlassian site (e.g. company.atlassian.net):',
+        default: currentValues.jiraCloudId || legacyCloudId || '',
+        when: (currentAnswers) => currentAnswers.jiraIntegrationType === 'mcp',
+        filter: (input: string) => input.trim().replace(/^https?:\/\//, '').replace(/\/+$/, ''),
+        validate: (input: string) => {
+          if (!input) return 'Site is required for MCP integration.';
+          if (!input.includes('.')) return 'Enter a hostname like company.atlassian.net.';
+          return true;
+        }
+      },
+      {
         type: 'input',
         name: 'mainBranch',
         message: 'Enter your main/production branch name:',
@@ -101,14 +126,15 @@ export async function initCommand(options: InitOptions): Promise<void> {
     ]);
 
     // Build config object — preserve existing fields and merge with new answers.
-    // Strip legacy MCP-related fields (removed in v8.0.0) so they don't persist on re-init.
-    const { cloudId: _cloudId, jiraIntegrationType: _jiraIntegrationType, ...preservedConfig } =
-      existingConfig as CoderyConfig & { cloudId?: string; jiraIntegrationType?: string };
+    // Strip the legacy pre-v5 `cloudId` field name; we use `jiraCloudId` now.
+    const { cloudId: _legacyCloudId, ...preservedConfig } =
+      existingConfig as CoderyConfig & { cloudId?: string };
     const config: CoderyConfig = {
       ...preservedConfig,
       projectKey: answers.projectKey,
       mainBranch: answers.mainBranch,
       gitWorkflowType: answers.gitWorkflowType,
+      jiraIntegrationType: answers.jiraIntegrationType,
       // Preserve applicationDocs if it exists, otherwise initialize as empty
       applicationDocs: existingConfig.applicationDocs || []
     };
@@ -119,6 +145,13 @@ export async function initCommand(options: InitOptions): Promise<void> {
     } else {
       // Remove developBranch if switching from gitflow to trunk-based
       delete config.developBranch;
+    }
+
+    // Only store cloudId for MCP integration; drop it when switching back to CLI.
+    if (answers.jiraIntegrationType === 'mcp') {
+      config.jiraCloudId = answers.jiraCloudId;
+    } else {
+      delete config.jiraCloudId;
     }
 
     // Write config
@@ -169,6 +202,10 @@ export async function initCommand(options: InitOptions): Promise<void> {
     console.log('Configuration summary:');
     console.log(`  - Git Workflow: ${chalk.cyan(config.gitWorkflowType === 'gitflow' ? 'Git Flow' : 'Trunk-Based Development')}`);
     console.log(`  - Project Key: ${chalk.cyan(config.projectKey)}`);
+    console.log(`  - JIRA Integration: ${chalk.cyan(config.jiraIntegrationType === 'mcp' ? 'Atlassian MCP' : 'JIRA CLI')}`);
+    if (config.jiraCloudId) {
+      console.log(`  - Atlassian Site: ${chalk.cyan(config.jiraCloudId)}`);
+    }
     console.log(`  - Main Branch: ${chalk.cyan(config.mainBranch)}`);
     if (config.developBranch) {
       console.log(`  - Develop Branch: ${chalk.cyan(config.developBranch)}`);
@@ -181,7 +218,11 @@ export async function initCommand(options: InitOptions): Promise<void> {
     console.log('  1. Review .codery/config.json and adjust if needed');
     console.log('  2. Run', chalk.yellow('codery build'), 'to generate your customized CLAUDE.md');
     console.log();
-    console.log(chalk.dim('Note: Make sure JIRA CLI is installed and configured with your API token.'));
+    if (config.jiraIntegrationType === 'mcp') {
+      console.log(chalk.dim('Note: Make sure the Atlassian MCP server is installed in Claude Code and authenticated to your Atlassian account.'));
+    } else {
+      console.log(chalk.dim('Note: Make sure JIRA CLI is installed and configured with your API token.'));
+    }
   } catch (error: any) {
     console.error(chalk.red('Init failed:'), error.message);
     throw error;

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -4,10 +4,13 @@ export interface CoderyConfig {
   mainBranch?: string;
   applicationDocs?: string[];
   gitWorkflowType?: 'gitflow' | 'trunk-based';
+  jiraIntegrationType?: 'mcp' | 'cli';
+  jiraCloudId?: string;
 }
 
 export const defaultConfig: CoderyConfig = {
   projectKey: 'YOUR_PROJECT_KEY',
   developBranch: 'develop',
   mainBranch: 'main',
+  jiraIntegrationType: 'cli',
 };


### PR DESCRIPTION
## Why

The Atlassian MCP integration was removed in v8.0.0 (COD-53) under the assumption of no active users. As Codery broadens beyond the original single-user audience, some new users will prefer the MCP over the JIRA CLI — so it's coming back as an opt-in alternative, coexisting with CLI on a per-project basis.

The reintroduction is informed by what we learned from the first incarnation: MCP tools are self-describing, so Codery does **not** need a big "how to call JIRA" reference file for MCP users. The project only needs to tell Claude *which* Atlassian site (`cloudId`) to target.

## What

- **Config**: adds `jiraIntegrationType: 'mcp' | 'cli'` (default `'cli'`) and `jiraCloudId`. Existing CLI-only configs continue to build without changes (backward compatible — no breaking change flag).
- **Templates**: `jira-reference.md` split into `jira-reference-cli.md` (existing command-oriented content) and new `jira-reference-mcp.md` (slim, ~20 lines, no tool-call syntax). Both variants drop hardcoded workflow states — projects define their own.
- **Preview & approval convention**: now applies only to ticket **create / edit / comment**. Transitions and worklogs proceed without approval — they're core workflow, not content creation.
- **Build**: `getJiraReferenceSource(config)` helper mirrors the existing `getGitWorkflowSource(config)` pattern. One line in `copyReferenceFiles()` picks the variant; output path stays `.codery/refs/jira-reference.md` so downstream `@imports` are unchanged.
- **Init**: adds a JIRA integration picker after the project-key prompt. When MCP is selected, a conditional `jiraCloudId` prompt follows — strips `http(s)://` and trailing slashes; validates that a hostname was entered.
- **Skills**: `codery-release` rewritten to drop hardcoded `jira issue view ... -p KEY --plain/--raw | jq` syntax in favor of integration-agnostic guidance ("fetch summary/type/priority/status; parent lives under `fields.parent` or an epic-link custom field"). Claude picks the right tool at runtime based on what the project config declares. The other 7 `codery-*` skills were already principle-driven and needed no changes.
- **Docs**: `engineering-docs/README.md` (build flow diagram + config structure + version history), `docs/configuration.md` (new field docs + MCP example), `docs/getting-started.md` (init-prompt summary), `docs/templates.md` (new template variable row).

## Evidence

- `npm run typecheck` — clean.
- `npm run build` — clean.
- `npm run lint` — no new errors; 12 pre-existing `any` warnings unchanged.
- **CLI path verified in-place**: ran `node dist/bin/codery.js build --force` in this project (config has no `jiraIntegrationType`, so default `'cli'` applies). Output `.codery/refs/jira-reference.md` begins with `# JIRA Reference (CLI)` — correct variant selected.
- **MCP path verified in sandbox**: created a temp dir with `jiraIntegrationType: "mcp"` and `jiraCloudId: "acme.atlassian.net"`. Build produced output beginning with `# JIRA Reference (Atlassian MCP)` and the cloudId substituted in place. Correct variant + correct template substitution.
- **Backward compat verified**: separate sandbox with an older-style config (no `jiraIntegrationType`) built cleanly and used the CLI variant.

## How to Verify

1. `npm run typecheck && npm run build && npm run lint`
2. Confirm the renamed/new template files exist:
   ```
   codery-docs/.codery/jira-reference-cli.md   # renamed from jira-reference.md
   codery-docs/.codery/jira-reference-mcp.md   # new, ~20 lines
   ```
3. **CLI sanity check (no new prompts needed)** — in any project that currently uses `codery`:
   ```
   node dist/bin/codery.js build --force
   head -3 .codery/refs/jira-reference.md   # should show "# JIRA Reference (CLI)"
   ```
4. **MCP sandbox**:
   ```
   SANDBOX=$(mktemp -d) && mkdir -p "$SANDBOX/.codery"
   cat > "$SANDBOX/.codery/config.json" <<JSON
   {"projectKey":"ACME","mainBranch":"main","gitWorkflowType":"trunk-based","jiraIntegrationType":"mcp","jiraCloudId":"acme.atlassian.net"}
   JSON
   cd "$SANDBOX" && node <path-to>/dist/bin/codery.js build --force
   head -5 .codery/refs/jira-reference.md   # should show "# JIRA Reference (Atlassian MCP)" with ACME + cloudId substituted
   ```
5. **Init flow** — run `codery init --force` in any project. Confirm:
   - New "How will Claude interact with JIRA?" prompt appears after project key.
   - Choosing `mcp` follows with an "Atlassian site" prompt; choosing `cli` skips it.
   - Pasting `https://acme.atlassian.net/` into the site prompt gets normalized to `acme.atlassian.net`.
   - Final summary displays the JIRA integration and (if MCP) the site.

## Reviewer Guidance

- Not breaking: `jiraIntegrationType` is optional; omitted configs get `'cli'` at build time. No migration is required for existing projects.
- The decision to keep the CLI reference file's command syntax intact (rather than also trimming it) was deliberate — MCP users don't need it, CLI users still do. Only drift was the hardcoded workflow-states block, removed in both variants per user feedback.
- `codery-release` is the only skill that hardcoded JIRA CLI syntax; the rewrite there is the bulk of the skill-level work. Worth a careful pass to confirm the guidance still gives enough direction without being tool-prescriptive.