### PR TITLE
feat(cli): add codery config command (COD-59)

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -123,6 +123,67 @@ If you have `applicationDocs` configured, the build process will also:
 - Create `.codery/application-docs.md`
 - Show warnings for any missing files but continue
 
+---
+
+### codery config
+
+View or edit `.codery/config.json` without re-running the full `codery init` wizard. Mirrors `git config` semantics with both an interactive menu and scriptable subcommands.
+
+**Usage:**
+```bash
+codery config                       # interactive menu (default)
+codery config list                  # print full config as JSON
+codery config get <key>             # print one field's value
+codery config set <key> <value>     # set a scalar field
+codery config unset <key>           # remove a field
+codery config add <key> <value>     # append to an array field (e.g. applicationDocs)
+codery config remove <key> <value>  # remove a value from an array field
+```
+
+**Interactive menu:**
+
+Bare `codery config` opens an arrow-key navigable list of every field with its current value. Select a field to edit it (list prompt for enums, validated input for scalars, sub-menu for arrays). Choose **Save & Exit** to persist or **Discard & Exit** to abandon changes (confirms if dirty).
+
+**Scriptable subcommands:**
+
+Designed for shell loops and CI. All commands operate on `.codery/config.json` in the current directory and exit non-zero on error.
+
+- `list` — pretty-prints the full config
+- `get <key>` — prints the field's value (newline-delimited for arrays); exit 1 if unset or unknown
+- `set <key> <value>` — validates and writes a scalar/enum field; rejects array fields
+- `unset <key>` — removes a field (no-op if already absent)
+- `add <key> <value>` — appends to an array field; rejects scalar fields
+- `remove <key> <value>` — removes a value from an array; exit 1 if not found
+
+**Validation:** uses the same per-field validators as `codery init` (extracted into `src/lib/configSchema.ts`). Filters apply consistently — e.g. `set jiraCloudId https://acme.atlassian.net/` stores `acme.atlassian.net`.
+
+**Stale-field warnings:** `set jiraIntegrationType cli` while `jiraCloudId` is set prints a warning to stderr but does **not** auto-unset. The interactive menu surfaces the same warnings inline next to the field. Run `unset` deliberately to clean up.
+
+**Examples:**
+
+Migrate a project from JIRA CLI to Atlassian MCP:
+```bash
+codery config set jiraIntegrationType mcp
+codery config set jiraCloudId company.atlassian.net
+codery build
+```
+
+Loop across multiple projects:
+```bash
+for dir in ~/projects/*/; do
+  (cd "$dir" && codery config set jiraIntegrationType cli)
+done
+```
+
+Inspect a single field:
+```bash
+codery config get projectKey
+```
+
+**Important:** `codery config` does **not** trigger a rebuild. Run `codery build` separately when ready.
+
+---
+
 ## Error Handling
 
 ### Common Errors
@@ -150,4 +211,5 @@ Display help for any command:
 codery --help
 codery init --help
 codery build --help
+codery config --help
 ```

--- a/engineering-docs/README.md
+++ b/engineering-docs/README.md
@@ -89,6 +89,14 @@ Codery follows the npm principle: **track inputs, ignore outputs**.
 
 ## Version History
 
+### Version 8.x - `codery config` Command (COD-59)
+- Added `codery config` for viewing and editing `.codery/config.json` without re-running `codery init`
+- Bare `codery config` opens an interactive arrow-key navigable menu listing all fields with current values; select to edit, with appropriate prompt per field type (list / input / array submenu)
+- Scriptable subcommands for shell loops: `codery config list | get <key> | set <key> <value> | unset <key> | add <key> <value> | remove <key> <value>`
+- Field validators extracted into `src/lib/configSchema.ts` and reused by both `codery init` and `codery config` to prevent drift
+- Stale-field warnings surface inline (e.g., `jiraCloudId` set while `jiraIntegrationType=cli`); strict semantics — `set` does not auto-cleanup paired fields
+- No automatic rebuild — run `codery build` separately when ready
+
 ### Version 8.x - Atlassian MCP Reintroduction (COD-57)
 - Reintroduced the Atlassian MCP as an opt-in JIRA integration alongside the CLI (removed in v8.0.0)
 - Config regains `jiraIntegrationType: 'mcp' | 'cli'` (default `cli` for backward compat) and `jiraCloudId`
@@ -178,6 +186,20 @@ Codery follows the npm principle: **track inputs, ignore outputs**.
 ### 4. Registry Commands (`codery register`, `codery unregister`, `codery list`)
 
 **Purpose**: Manage the project registry for `codery update`.
+
+### 5. Config Command (`codery config`)
+
+**Purpose**: View and edit `.codery/config.json` without re-running the full `codery init` wizard.
+
+**Two surfaces**:
+- **Interactive**: `codery config` (bare) opens a menu listing all fields with current values. Use arrow keys + Enter to pick a field, edit it (with the same validators init uses), and return to the menu. Choose Save & Exit / Discard & Exit.
+- **Scriptable**: `codery config list | get <key> | set <key> <value> | unset <key> | add <key> <value> | remove <key> <value>` — for shell loops and CI.
+
+**Validation**: per-field validators live in `src/lib/configSchema.ts` and are shared with `codery init`. Filters (e.g., stripping `https://` from `jiraCloudId`) apply consistently in both interactive and scriptable paths.
+
+**Stale-field warnings**: `set jiraIntegrationType cli` while `jiraCloudId` is set will print a warning but not auto-unset; the menu shows the warning inline next to the field. Strict semantics — `set` does one thing.
+
+**Does not trigger a rebuild**: run `codery build` separately when ready.
 
 ## Implementation Details
 
@@ -275,6 +297,13 @@ codery update [--yes]
 codery register [path]
 codery unregister [path]
 codery list
+codery config                      # interactive menu
+codery config list                 # print full config
+codery config get <key>            # print one field
+codery config set <key> <value>    # set scalar field
+codery config unset <key>          # remove a field
+codery config add <key> <value>    # append to array field (applicationDocs)
+codery config remove <key> <value> # remove from array field
 ```
 
 ## Troubleshooting

--- a/src/bin/codery.ts
+++ b/src/bin/codery.ts
@@ -8,11 +8,15 @@ import { buildCommand } from '../lib/buildDocs';
 import { initCommand } from '../lib/initCommand';
 import { updateCommand } from '../lib/updateCommand';
 import {
-  addProject,
-  removeProject,
-  listProjects,
-  projectExists,
-} from '../lib/registry';
+  configList,
+  configGet,
+  configSet,
+  configUnset,
+  configAdd,
+  configRemove,
+  configMenu,
+} from '../lib/configCommand';
+import { addProject, removeProject, listProjects, projectExists } from '../lib/registry';
 
 // Read version from package.json
 const packageJsonPath = path.resolve(__dirname, '../../package.json');
@@ -114,7 +118,9 @@ program
 
       if (projects.length === 0) {
         console.log(chalk.yellow('No projects registered.'));
-        console.log(chalk.dim('Run `codery init` in a project or `codery register` to add projects.'));
+        console.log(
+          chalk.dim('Run `codery init` in a project or `codery register` to add projects.')
+        );
         return;
       }
 
@@ -129,6 +135,92 @@ program
 
       console.log();
       console.log(`${projects.length} project(s) registered`);
+    } catch (error: any) {
+      console.error(chalk.red('Error:'), error.message);
+      process.exit(1);
+    }
+  });
+
+const configCmd = program.command('config').description('View or edit Codery configuration');
+
+configCmd
+  .command('menu', { isDefault: true })
+  .description('Open interactive config menu (default)')
+  .action(async () => {
+    try {
+      await configMenu();
+    } catch (error: any) {
+      console.error(chalk.red('Error:'), error.message);
+      process.exit(1);
+    }
+  });
+
+configCmd
+  .command('list')
+  .description('Print the full configuration as JSON')
+  .action(() => {
+    try {
+      configList();
+    } catch (error: any) {
+      console.error(chalk.red('Error:'), error.message);
+      process.exit(1);
+    }
+  });
+
+configCmd
+  .command('get <key>')
+  .description('Print the value of a single config field')
+  .action((key: string) => {
+    try {
+      configGet(key);
+    } catch (error: any) {
+      console.error(chalk.red('Error:'), error.message);
+      process.exit(1);
+    }
+  });
+
+configCmd
+  .command('set <key> <value>')
+  .description('Set a scalar config field')
+  .action((key: string, value: string) => {
+    try {
+      configSet(key, value);
+    } catch (error: any) {
+      console.error(chalk.red('Error:'), error.message);
+      process.exit(1);
+    }
+  });
+
+configCmd
+  .command('unset <key>')
+  .description('Remove a config field')
+  .action((key: string) => {
+    try {
+      configUnset(key);
+    } catch (error: any) {
+      console.error(chalk.red('Error:'), error.message);
+      process.exit(1);
+    }
+  });
+
+configCmd
+  .command('add <key> <value>')
+  .description('Append a value to an array config field (e.g., applicationDocs)')
+  .action((key: string, value: string) => {
+    try {
+      configAdd(key, value);
+    } catch (error: any) {
+      console.error(chalk.red('Error:'), error.message);
+      process.exit(1);
+    }
+  });
+
+configCmd
+  .command('remove <key> <value>')
+  .description('Remove a value from an array config field')
+  .action((key: string, value: string) => {
+    try {
+      configRemove(key, value);
     } catch (error: any) {
       console.error(chalk.red('Error:'), error.message);
       process.exit(1);

--- a/src/lib/configCommand.ts
+++ b/src/lib/configCommand.ts
@@ -1,0 +1,361 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import chalk from 'chalk';
+import inquirer from 'inquirer';
+import { CoderyConfig } from '../types/config';
+import {
+  configSchema,
+  ConfigKey,
+  FieldSchema,
+  isValidKey,
+  applyScalarFilter,
+  validateScalarValue,
+  validateArrayItem,
+  detectStaleFields,
+} from './configSchema';
+
+interface LoadedConfig {
+  config: CoderyConfig;
+  configPath: string;
+}
+
+function asRecord(config: CoderyConfig): Record<string, unknown> {
+  return config as unknown as Record<string, unknown>;
+}
+
+function loadConfig(): LoadedConfig {
+  const configPath = path.join(process.cwd(), '.codery', 'config.json');
+  if (!fs.existsSync(configPath)) {
+    console.error(chalk.red('Error:'), 'No Codery configuration found in this directory.');
+    console.error(chalk.dim('Run `codery init` to create one.'));
+    process.exit(1);
+  }
+  let config: CoderyConfig;
+  try {
+    config = JSON.parse(fs.readFileSync(configPath, 'utf-8')) as CoderyConfig;
+  } catch (error: any) {
+    console.error(chalk.red('Error:'), `Could not parse ${configPath}: ${error.message}`);
+    process.exit(1);
+  }
+  return { config, configPath };
+}
+
+function saveConfig(config: CoderyConfig, configPath: string): void {
+  fs.writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n', 'utf-8');
+}
+
+function ensureKey(key: string): asserts key is ConfigKey {
+  if (!isValidKey(key)) {
+    const valid = Object.keys(configSchema).join(', ');
+    console.error(chalk.red('Error:'), `Unknown config key: ${key}`);
+    console.error(chalk.dim(`Valid keys: ${valid}`));
+    process.exit(1);
+  }
+}
+
+function warnStaleFields(config: CoderyConfig): void {
+  for (const w of detectStaleFields(config)) {
+    console.warn(chalk.yellow('⚠'), `${w.key}: ${w.message}`);
+  }
+}
+
+export function configList(): void {
+  const { config } = loadConfig();
+  console.log(JSON.stringify(config, null, 2));
+}
+
+export function configGet(key: string): void {
+  ensureKey(key);
+  const { config } = loadConfig();
+  const value = asRecord(config)[key];
+  if (value === undefined) {
+    console.error(chalk.red('Error:'), `Key "${key}" is not set.`);
+    process.exit(1);
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) console.log(item);
+  } else {
+    console.log(value);
+  }
+}
+
+export function configSet(key: string, rawValue: string): void {
+  ensureKey(key);
+  const field = configSchema[key];
+  if (field.kind === 'array') {
+    console.error(
+      chalk.red('Error:'),
+      `"${key}" is an array field; use \`codery config add\` / \`remove\`.`
+    );
+    process.exit(1);
+  }
+  const filtered = applyScalarFilter(key, rawValue);
+  const result = validateScalarValue(key, filtered);
+  if (result !== true) {
+    console.error(chalk.red('Error:'), result);
+    process.exit(1);
+  }
+  const { config, configPath } = loadConfig();
+  asRecord(config)[key] = filtered;
+  saveConfig(config, configPath);
+  console.log(chalk.green('✓'), `${key} = ${filtered}`);
+  warnStaleFields(config);
+}
+
+export function configUnset(key: string): void {
+  ensureKey(key);
+  const { config, configPath } = loadConfig();
+  if (asRecord(config)[key] === undefined) {
+    console.log(chalk.dim(`${key} was not set; nothing to unset.`));
+    return;
+  }
+  delete asRecord(config)[key];
+  saveConfig(config, configPath);
+  console.log(chalk.green('✓'), `Unset ${key}`);
+}
+
+export function configAdd(key: string, rawValue: string): void {
+  ensureKey(key);
+  const field = configSchema[key];
+  if (field.kind !== 'array') {
+    console.error(
+      chalk.red('Error:'),
+      `"${key}" is not an array field; use \`codery config set\`.`
+    );
+    process.exit(1);
+  }
+  const result = validateArrayItem(key, rawValue);
+  if (result !== true) {
+    console.error(chalk.red('Error:'), result);
+    process.exit(1);
+  }
+  const { config, configPath } = loadConfig();
+  const arr = (asRecord(config)[key] as string[] | undefined) ?? [];
+  arr.push(rawValue);
+  asRecord(config)[key] = arr;
+  saveConfig(config, configPath);
+  console.log(chalk.green('✓'), `Added "${rawValue}" to ${key}`);
+}
+
+export function configRemove(key: string, rawValue: string): void {
+  ensureKey(key);
+  const field = configSchema[key];
+  if (field.kind !== 'array') {
+    console.error(
+      chalk.red('Error:'),
+      `"${key}" is not an array field; use \`codery config unset\`.`
+    );
+    process.exit(1);
+  }
+  const { config, configPath } = loadConfig();
+  const arr = (asRecord(config)[key] as string[] | undefined) ?? [];
+  const idx = arr.indexOf(rawValue);
+  if (idx === -1) {
+    console.error(chalk.red('Error:'), `"${rawValue}" not found in ${key}`);
+    process.exit(1);
+  }
+  arr.splice(idx, 1);
+  if (arr.length === 0) {
+    delete asRecord(config)[key];
+  } else {
+    asRecord(config)[key] = arr;
+  }
+  saveConfig(config, configPath);
+  console.log(chalk.green('✓'), `Removed "${rawValue}" from ${key}`);
+}
+
+function formatValue(value: unknown): string {
+  if (value === undefined) return chalk.dim('(not set)');
+  if (Array.isArray(value)) {
+    if (value.length === 0) return chalk.dim('(empty)');
+    return chalk.cyan(`[${value.length} item${value.length === 1 ? '' : 's'}]`);
+  }
+  return chalk.cyan(String(value));
+}
+
+export async function configMenu(): Promise<void> {
+  const { config, configPath } = loadConfig();
+  const working: CoderyConfig = JSON.parse(JSON.stringify(config));
+  let dirty = false;
+
+  console.log(chalk.blue('🛠️  Codery config'));
+  console.log(chalk.dim(`File: ${configPath}`));
+  console.log();
+
+  while (true) {
+    const warnings = detectStaleFields(working);
+    const warningMap = new Map(warnings.map(w => [w.key, w.message]));
+
+    const fieldChoices = (Object.keys(configSchema) as ConfigKey[]).map(key => {
+      const value = asRecord(working)[key];
+      const display = formatValue(value);
+      const warning = warningMap.get(key);
+      const name = warning
+        ? `${key}: ${display} ${chalk.yellow(`⚠ ${warning}`)}`
+        : `${key}: ${display}`;
+      return { name, value: key };
+    });
+
+    const { selected } = await inquirer.prompt<{ selected: string }>([
+      {
+        type: 'list',
+        name: 'selected',
+        message: dirty ? 'Codery config (unsaved changes):' : 'Codery config:',
+        pageSize: 15,
+        choices: [
+          ...fieldChoices,
+          new inquirer.Separator(),
+          { name: 'Save & Exit', value: '__save__' },
+          { name: 'Discard & Exit', value: '__discard__' },
+        ],
+      },
+    ]);
+
+    if (selected === '__save__') {
+      if (!dirty) {
+        console.log(chalk.dim('No changes to save.'));
+        return;
+      }
+      saveConfig(working, configPath);
+      console.log(chalk.green('✓'), 'Configuration saved.');
+      warnStaleFields(working);
+      return;
+    }
+    if (selected === '__discard__') {
+      if (dirty) {
+        const { confirmDiscard } = await inquirer.prompt<{ confirmDiscard: boolean }>([
+          {
+            type: 'confirm',
+            name: 'confirmDiscard',
+            message: 'Discard unsaved changes?',
+            default: false,
+          },
+        ]);
+        if (!confirmDiscard) continue;
+      }
+      console.log(chalk.dim('Discarded changes.'));
+      return;
+    }
+
+    const changed = await editField(working, selected as ConfigKey);
+    if (changed) dirty = true;
+  }
+}
+
+async function editField(config: CoderyConfig, key: ConfigKey): Promise<boolean> {
+  const field = configSchema[key];
+  const current = asRecord(config)[key];
+
+  if (field.kind === 'enum') {
+    return editEnumField(config, key, field, current as string | undefined);
+  }
+  if (field.kind === 'scalar') {
+    return editScalarField(config, key, field, current as string | undefined);
+  }
+  return editArrayField(config, key, field);
+}
+
+async function editEnumField(
+  config: CoderyConfig,
+  key: ConfigKey,
+  field: Extract<FieldSchema, { kind: 'enum' }>,
+  current: string | undefined
+): Promise<boolean> {
+  const { value } = await inquirer.prompt<{ value: string }>([
+    {
+      type: 'list',
+      name: 'value',
+      message: `${key}:`,
+      choices: field.choices.map(c => ({ name: c, value: c })),
+      default: current,
+    },
+  ]);
+  if (value !== current) {
+    asRecord(config)[key] = value;
+    return true;
+  }
+  return false;
+}
+
+async function editScalarField(
+  config: CoderyConfig,
+  key: ConfigKey,
+  field: Extract<FieldSchema, { kind: 'scalar' }>,
+  current: string | undefined
+): Promise<boolean> {
+  const { value } = await inquirer.prompt<{ value: string }>([
+    {
+      type: 'input',
+      name: 'value',
+      message: `${key}:`,
+      default: current ?? '',
+      filter: field.filter,
+      validate: field.validate,
+    },
+  ]);
+  if (value !== current) {
+    asRecord(config)[key] = value;
+    return true;
+  }
+  return false;
+}
+
+async function editArrayField(
+  config: CoderyConfig,
+  key: ConfigKey,
+  field: Extract<FieldSchema, { kind: 'array' }>
+): Promise<boolean> {
+  let changed = false;
+  while (true) {
+    const arr = (asRecord(config)[key] as string[] | undefined) ?? [];
+    const itemChoices = arr.map((item, i) => ({
+      name: `${i + 1}. ${item}`,
+      value: `__remove__:${i}`,
+    }));
+
+    const { action } = await inquirer.prompt<{ action: string }>([
+      {
+        type: 'list',
+        name: 'action',
+        message: `${key}:`,
+        pageSize: 15,
+        choices: [
+          ...itemChoices,
+          new inquirer.Separator(),
+          { name: '+ Add path', value: '__add__' },
+          { name: '← Back', value: '__back__' },
+        ],
+      },
+    ]);
+
+    if (action === '__back__') return changed;
+
+    if (action === '__add__') {
+      const { newItem } = await inquirer.prompt<{ newItem: string }>([
+        {
+          type: 'input',
+          name: 'newItem',
+          message: 'New path:',
+          validate: field.itemValidate,
+        },
+      ]);
+      const newArr = [...arr, newItem];
+      asRecord(config)[key] = newArr;
+      changed = true;
+      continue;
+    }
+
+    if (action.startsWith('__remove__:')) {
+      const idx = Number(action.split(':')[1]);
+      const newArr = [...arr];
+      newArr.splice(idx, 1);
+      if (newArr.length === 0) {
+        delete asRecord(config)[key];
+      } else {
+        asRecord(config)[key] = newArr;
+      }
+      changed = true;
+      continue;
+    }
+  }
+}

--- a/src/lib/configSchema.ts
+++ b/src/lib/configSchema.ts
@@ -19,7 +19,6 @@ export interface EnumField extends BaseField {
 
 export interface ArrayField extends BaseField {
   kind: 'array';
-  itemFilter?: (input: string) => string;
   itemValidate?: (input: string) => true | string;
 }
 
@@ -62,10 +61,12 @@ export const configSchema: Record<ConfigKey, FieldSchema> = {
   mainBranch: {
     kind: 'scalar',
     description: 'Main/production branch name',
+    validate: validateNonEmpty,
   },
   developBranch: {
     kind: 'scalar',
     description: 'Development branch name (used with gitflow)',
+    validate: validateNonEmpty,
   },
   jiraIntegrationType: {
     kind: 'enum',

--- a/src/lib/configSchema.ts
+++ b/src/lib/configSchema.ts
@@ -1,0 +1,137 @@
+import { CoderyConfig } from '../types/config';
+
+export type ConfigKey = keyof CoderyConfig;
+
+interface BaseField {
+  description: string;
+}
+
+export interface ScalarField extends BaseField {
+  kind: 'scalar';
+  filter?: (input: string) => string;
+  validate?: (input: string) => true | string;
+}
+
+export interface EnumField extends BaseField {
+  kind: 'enum';
+  choices: readonly string[];
+}
+
+export interface ArrayField extends BaseField {
+  kind: 'array';
+  itemFilter?: (input: string) => string;
+  itemValidate?: (input: string) => true | string;
+}
+
+export type FieldSchema = ScalarField | EnumField | ArrayField;
+
+export function validateProjectKey(input: string): true | string {
+  if (input.match(/^[A-Z][A-Z0-9]*$/)) return true;
+  return 'Project key must be uppercase letters and numbers (e.g., PROJ, MVP, ACME)';
+}
+
+export function filterCloudId(input: string): string {
+  return input
+    .trim()
+    .replace(/^https?:\/\//, '')
+    .replace(/\/+$/, '');
+}
+
+export function validateCloudId(input: string): true | string {
+  if (!input) return 'Atlassian site is required.';
+  if (!input.includes('.')) return 'Enter a hostname like company.atlassian.net.';
+  return true;
+}
+
+export function validateNonEmpty(input: string): true | string {
+  if (!input.trim()) return 'Value cannot be empty.';
+  return true;
+}
+
+export const configSchema: Record<ConfigKey, FieldSchema> = {
+  projectKey: {
+    kind: 'scalar',
+    description: 'JIRA project key (uppercase letters and numbers)',
+    validate: validateProjectKey,
+  },
+  gitWorkflowType: {
+    kind: 'enum',
+    description: 'Git workflow style',
+    choices: ['gitflow', 'trunk-based'] as const,
+  },
+  mainBranch: {
+    kind: 'scalar',
+    description: 'Main/production branch name',
+  },
+  developBranch: {
+    kind: 'scalar',
+    description: 'Development branch name (used with gitflow)',
+  },
+  jiraIntegrationType: {
+    kind: 'enum',
+    description: 'How AI agents interact with JIRA',
+    choices: ['cli', 'mcp'] as const,
+  },
+  jiraCloudId: {
+    kind: 'scalar',
+    description: 'Atlassian site hostname (used with MCP integration)',
+    filter: filterCloudId,
+    validate: validateCloudId,
+  },
+  applicationDocs: {
+    kind: 'array',
+    description: 'Paths to project-specific docs imported into CLAUDE.md',
+    itemValidate: validateNonEmpty,
+  },
+};
+
+export function isValidKey(key: string): key is ConfigKey {
+  return Object.prototype.hasOwnProperty.call(configSchema, key);
+}
+
+export function applyScalarFilter(key: ConfigKey, raw: string): string {
+  const field = configSchema[key];
+  if (field.kind === 'scalar' && field.filter) return field.filter(raw);
+  return raw;
+}
+
+export function validateScalarValue(key: ConfigKey, value: string): true | string {
+  const field = configSchema[key];
+  if (field.kind === 'enum') {
+    return field.choices.includes(value) ? true : `Must be one of: ${field.choices.join(', ')}`;
+  }
+  if (field.kind === 'array') {
+    return `"${key}" is an array field; use \`codery config add\` / \`remove\`.`;
+  }
+  return field.validate ? field.validate(value) : true;
+}
+
+export function validateArrayItem(key: ConfigKey, value: string): true | string {
+  const field = configSchema[key];
+  if (field.kind !== 'array') {
+    return `"${key}" is not an array field; use \`codery config set\`.`;
+  }
+  return field.itemValidate ? field.itemValidate(value) : true;
+}
+
+export interface StaleWarning {
+  key: ConfigKey;
+  message: string;
+}
+
+export function detectStaleFields(config: CoderyConfig): StaleWarning[] {
+  const warnings: StaleWarning[] = [];
+  if (config.jiraIntegrationType === 'cli' && config.jiraCloudId) {
+    warnings.push({
+      key: 'jiraCloudId',
+      message: 'set but jiraIntegrationType is cli (unused)',
+    });
+  }
+  if (config.gitWorkflowType === 'trunk-based' && config.developBranch) {
+    warnings.push({
+      key: 'developBranch',
+      message: 'set but gitWorkflowType is trunk-based (unused)',
+    });
+  }
+  return warnings;
+}

--- a/src/lib/initCommand.ts
+++ b/src/lib/initCommand.ts
@@ -4,6 +4,7 @@ import chalk from 'chalk';
 import inquirer from 'inquirer';
 import { defaultConfig, CoderyConfig } from '../types/config';
 import { addProject } from './registry';
+import { validateProjectKey, filterCloudId, validateCloudId } from './configSchema';
 
 interface InitOptions {
   force?: boolean;
@@ -59,7 +60,7 @@ export async function initCommand(options: InitOptions): Promise<void> {
     }
 
     // Prompt for configuration values
-    console.log('Let\'s configure your project:');
+    console.log("Let's configure your project:");
     console.log();
 
     const legacyCloudId = (existingConfig as CoderyConfig & { cloudId?: string }).cloudId;
@@ -71,21 +72,16 @@ export async function initCommand(options: InitOptions): Promise<void> {
         message: 'Select your Git workflow type:',
         choices: [
           { name: 'Git Flow (feature branches, develop/main)', value: 'gitflow' },
-          { name: 'Trunk-Based (direct commits to main)', value: 'trunk-based' }
+          { name: 'Trunk-Based (direct commits to main)', value: 'trunk-based' },
         ],
-        default: currentValues.gitWorkflowType || 'gitflow'
+        default: currentValues.gitWorkflowType || 'gitflow',
       },
       {
         type: 'input',
         name: 'projectKey',
         message: 'Enter your JIRA project key:',
         default: currentValues.projectKey,
-        validate: (input: string) => {
-          if (input.match(/^[A-Z][A-Z0-9]*$/)) {
-            return true;
-          }
-          return 'Project key must be uppercase letters and numbers (e.g., PROJ, MVP, ACME)';
-        }
+        validate: validateProjectKey,
       },
       {
         type: 'list',
@@ -93,43 +89,40 @@ export async function initCommand(options: InitOptions): Promise<void> {
         message: 'How will Claude interact with JIRA?',
         choices: [
           { name: 'JIRA CLI (requires `jira` CLI installed with an API token)', value: 'cli' },
-          { name: 'Atlassian MCP (configure an MCP server in Claude Code)', value: 'mcp' }
+          { name: 'Atlassian MCP (configure an MCP server in Claude Code)', value: 'mcp' },
         ],
-        default: currentValues.jiraIntegrationType || 'cli'
+        default: currentValues.jiraIntegrationType || 'cli',
       },
       {
         type: 'input',
         name: 'jiraCloudId',
         message: 'Atlassian site (e.g. company.atlassian.net):',
         default: currentValues.jiraCloudId || legacyCloudId || '',
-        when: (currentAnswers) => currentAnswers.jiraIntegrationType === 'mcp',
-        filter: (input: string) => input.trim().replace(/^https?:\/\//, '').replace(/\/+$/, ''),
-        validate: (input: string) => {
-          if (!input) return 'Site is required for MCP integration.';
-          if (!input.includes('.')) return 'Enter a hostname like company.atlassian.net.';
-          return true;
-        }
+        when: currentAnswers => currentAnswers.jiraIntegrationType === 'mcp',
+        filter: filterCloudId,
+        validate: validateCloudId,
       },
       {
         type: 'input',
         name: 'mainBranch',
         message: 'Enter your main/production branch name:',
-        default: currentValues.mainBranch || 'main'
+        default: currentValues.mainBranch || 'main',
       },
       {
         type: 'input',
         name: 'developBranch',
         message: 'Enter your development branch name:',
         default: currentValues.developBranch || 'develop',
-        when: (currentAnswers) => currentAnswers.gitWorkflowType === 'gitflow'
-      }
+        when: currentAnswers => currentAnswers.gitWorkflowType === 'gitflow',
+      },
     ]);
 
     // Build config object — preserve existing fields and merge with new answers.
     // Strip the legacy v5–v7 `cloudId` field name (removed in v8.0.0). The
     // current field is `jiraCloudId` and stores a hostname, not a full URL.
-    const { cloudId: _legacyCloudId, ...preservedConfig } =
-      existingConfig as CoderyConfig & { cloudId?: string };
+    const { cloudId: _legacyCloudId, ...preservedConfig } = existingConfig as CoderyConfig & {
+      cloudId?: string;
+    };
     const config: CoderyConfig = {
       ...preservedConfig,
       projectKey: answers.projectKey,
@@ -137,7 +130,7 @@ export async function initCommand(options: InitOptions): Promise<void> {
       gitWorkflowType: answers.gitWorkflowType,
       jiraIntegrationType: answers.jiraIntegrationType,
       // Preserve applicationDocs if it exists, otherwise initialize as empty
-      applicationDocs: existingConfig.applicationDocs || []
+      applicationDocs: existingConfig.applicationDocs || [],
     };
 
     // Only add developBranch for gitflow
@@ -168,11 +161,7 @@ export async function initCommand(options: InitOptions): Promise<void> {
       const entriesToAdd: string[] = [];
 
       // Generated files that should be ignored (like node_modules)
-      const generatedFiles = [
-        'CLAUDE.md',
-        '.claude/',
-        '.codery/refs/',
-      ];
+      const generatedFiles = ['CLAUDE.md', '.claude/', '.codery/refs/'];
 
       for (const entry of generatedFiles) {
         if (!gitignoreContent.includes(entry)) {
@@ -187,7 +176,10 @@ export async function initCommand(options: InitOptions): Promise<void> {
           entriesToAdd.join('\n') +
           '\n';
         fs.writeFileSync(gitignorePath, updatedContent, 'utf-8');
-        console.log(chalk.green('✓'), `Added ${entriesToAdd.length} Codery generated file(s) to .gitignore`);
+        console.log(
+          chalk.green('✓'),
+          `Added ${entriesToAdd.length} Codery generated file(s) to .gitignore`
+        );
       }
     }
 
@@ -201,9 +193,13 @@ export async function initCommand(options: InitOptions): Promise<void> {
     console.log(chalk.green('✨ Codery configuration updated!'));
     console.log();
     console.log('Configuration summary:');
-    console.log(`  - Git Workflow: ${chalk.cyan(config.gitWorkflowType === 'gitflow' ? 'Git Flow' : 'Trunk-Based Development')}`);
+    console.log(
+      `  - Git Workflow: ${chalk.cyan(config.gitWorkflowType === 'gitflow' ? 'Git Flow' : 'Trunk-Based Development')}`
+    );
     console.log(`  - Project Key: ${chalk.cyan(config.projectKey)}`);
-    console.log(`  - JIRA Integration: ${chalk.cyan(config.jiraIntegrationType === 'mcp' ? 'Atlassian MCP' : 'JIRA CLI')}`);
+    console.log(
+      `  - JIRA Integration: ${chalk.cyan(config.jiraIntegrationType === 'mcp' ? 'Atlassian MCP' : 'JIRA CLI')}`
+    );
     if (config.jiraCloudId) {
       console.log(`  - Atlassian Site: ${chalk.cyan(config.jiraCloudId)}`);
     }
@@ -212,7 +208,9 @@ export async function initCommand(options: InitOptions): Promise<void> {
       console.log(`  - Develop Branch: ${chalk.cyan(config.developBranch)}`);
     }
     if (config.applicationDocs && config.applicationDocs.length > 0) {
-      console.log(`  - Application Docs: ${chalk.cyan(`${config.applicationDocs.length} path(s) preserved`)}`);
+      console.log(
+        `  - Application Docs: ${chalk.cyan(`${config.applicationDocs.length} path(s) preserved`)}`
+      );
     }
     console.log();
     console.log('Next steps:');
@@ -220,9 +218,15 @@ export async function initCommand(options: InitOptions): Promise<void> {
     console.log('  2. Run', chalk.yellow('codery build'), 'to generate your customized CLAUDE.md');
     console.log();
     if (config.jiraIntegrationType === 'mcp') {
-      console.log(chalk.dim('Note: Make sure the Atlassian MCP server is installed in Claude Code and authenticated to your Atlassian account.'));
+      console.log(
+        chalk.dim(
+          'Note: Make sure the Atlassian MCP server is installed in Claude Code and authenticated to your Atlassian account.'
+        )
+      );
     } else {
-      console.log(chalk.dim('Note: Make sure JIRA CLI is installed and configured with your API token.'));
+      console.log(
+        chalk.dim('Note: Make sure JIRA CLI is installed and configured with your API token.')
+      );
     }
   } catch (error: any) {
     console.error(chalk.red('Init failed:'), error.message);


### PR DESCRIPTION
## Why

Multi-project Codery users need to migrate config (notably `jiraIntegrationType` between `cli` and `mcp` introduced by COD-57) without re-running the full `codery init` wizard each time. Re-running init walks through every field sequentially per project — too slow for bulk migration and revert. This adds a focused config editor with two surfaces: an interactive arrow-key menu for one-off edits, and scriptable subcommands so users can pipeline edits across projects in shell loops.

Mirrors `git config` / `claude config` semantics. JIRA: COD-59.

## What

- New `codery config` command with two surfaces:
  - **Bare** `codery config` opens an interactive `inquirer` menu listing every field with current value; select to edit (list / input / array sub-menu); Save & Exit / Discard & Exit.
  - **Scriptable** subcommands: `list`, `get <key>`, `set <key> <value>`, `unset <key>`, `add <key> <value>`, `remove <key> <value>`.
- New `src/lib/configSchema.ts` — single source of truth for field shape (kind: scalar / enum / array), validators, filters, choices, plus stale-field detection.
- `codery init` refactored to import the same `validateProjectKey`, `filterCloudId`, `validateCloudId` functions — schema and init can no longer drift.
- Stale-field warnings surface inline in the menu (`⚠ unused (cli mode)`) and on stderr after `set`. Strict semantics — `set jiraIntegrationType cli` does not auto-unset `jiraCloudId`; user runs `unset` deliberately.
- Filters apply consistently in both interactive and scriptable paths: `set jiraCloudId https://acme.atlassian.net/` stores `acme.atlassian.net`.
- `get` for arrays prints newline-delimited values (composes with shell tools); for scalars prints the bare value; non-zero exit if key unset or unknown.
- Friendly error when run outside a Codery project — directs user to `codery init`.
- No automatic rebuild — user runs `codery build` separately when ready.
- Engineering-docs README updated with command listing and new "Config Command" section.

## Evidence

Manually exercised every scriptable subcommand against the live `.codery/config.json`:

- `config list` → prints pretty JSON
- `config get projectKey` → `COD`
- `config get applicationDocs` → newline-delimited paths
- `config get jiraIntegrationType` (unset) → stderr error, exit 1
- `config get bogus` (unknown) → stderr error listing valid keys, exit 1
- `config set jiraIntegrationType mcp` → ok
- `config set jiraIntegrationType bogus` → enum error, exit 1
- `config set jiraCloudId https://acme.atlassian.net/` → filter strips → stored `acme.atlassian.net`
- `config set jiraCloudId nodot` → hostname error, exit 1
- `config set projectKey lowercase` → regex error, exit 1
- `config set jiraIntegrationType cli` (with `jiraCloudId` set) → success + stale-field warning to stderr
- `config unset jiraCloudId` → ok; second unset → "was not set; nothing to unset."
- `config add applicationDocs docs/extra.md` / `remove applicationDocs docs/extra.md` → ok
- `config remove applicationDocs not-there.md` → not-found error, exit 1
- `config add projectKey FOO` → "not an array field" error, exit 1
- `config set applicationDocs foo.md` → "is an array field" error, exit 1
- Run from a directory without `.codery/config.json` → directs to `codery init`, exit 1
- `codery config --help` lists all subcommands

`npm run typecheck` clean (0 errors). `npm run lint` 0 errors / 20 warnings — only one new warning in this PR (`error: any` in a catch, matching existing pattern in `initCommand.ts` / `buildDocs.ts` / `updateCommand.ts`). `npm run build` clean.

The interactive menu was not exercised end-to-end (requires a TTY the test harness doesn't have); reviewer guidance below covers manual verification.

## How to Verify

```bash
git checkout feature/COD-59-codery-config-command
npm install && npm run build

# Interactive menu (run in a real terminal):
node dist/bin/codery.js config
# - arrow keys list every field with current value
# - select jiraIntegrationType → list with cli/mcp
# - select jiraCloudId → input with hostname validation; pasting https://X/ strips to X
# - select applicationDocs → submenu Add / Remove / Back
# - Save & Exit writes to .codery/config.json; Discard & Exit asks for confirm if dirty

# Scriptable smoke test (any Codery project):
node dist/bin/codery.js config list
node dist/bin/codery.js config set jiraIntegrationType mcp
node dist/bin/codery.js config set jiraCloudId https://example.atlassian.net/
node dist/bin/codery.js config get jiraCloudId   # → example.atlassian.net
node dist/bin/codery.js config set jiraIntegrationType cli  # warns about stale jiraCloudId
node dist/bin/codery.js config unset jiraCloudId

# Error paths:
node dist/bin/codery.js config get bogus            # exit 1
node dist/bin/codery.js config set projectKey lower # exit 1
cd /tmp && node /path/to/dist/bin/codery.js config list   # exit 1, suggests codery init
```

## Reviewer Guidance

- The `asRecord(config)` helper in `configCommand.ts` is a `unknown`-cast bridge so the dynamic-key paths don't need per-call casts. Restricted to this file; types stay strict at the boundary (`ConfigKey` from schema, `ensureKey` narrows).
- `codery init` was refactored to import the shared validators; the prompt UX (choice display names, conditional `when` clauses) is unchanged. Worth a quick scan to confirm no behavioral drift.
- No tests added — Jest is in deps but the project has no test infrastructure (no config, no `@types/jest`, no existing test files). Adding it is out of scope for this ticket; logging as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)