### PR TITLE
feat(skills): load full JIRA hierarchy in codery-status (COD-60)

### DIFF
--- a/codery-docs/.codery/skills/codery-status/SKILL.md
+++ b/codery-docs/.codery/skills/codery-status/SKILL.md
@@ -7,30 +7,39 @@ argument-hint: <PR-number or ticket-id>
 
 **Goal**: Give the user a complete understanding of where this PR/ticket stands so they can make informed decisions.
 
-## Context Loading
+## Find the Entry Point
 
-Based on the argument, load related context:
+**PR number** → Fetch PR, find linked JIRA ticket.
+**Ticket ID** → Use directly.
+**No argument** → Check current branch for ticket pattern or open PR.
 
-**If PR number given**: Fetch PR details, find linked JIRA ticket, load both.
-**If ticket ID given**: Fetch ticket, check for linked PR, load both.
-**If no argument**: Check current branch for ticket pattern or open PR.
+## Load the Hierarchy
+
+A JIRA ticket only makes sense in its hierarchy. From the entry point, **load every ancestor up to the root, plus the entry's immediate context** — its children if it has any, otherwise its siblings. Never just the single ticket. Read comments on every loaded node; comments carry the decisions and blockers that the fields don't show.
+
+| Entry point | Also load |
+|---|---|
+| Subtask | parent Story, Story's Epic, sibling subtasks |
+| Story | Epic, child subtasks |
+| Epic | child Stories (skip the subtask layer unless something points there) |
+
+Don't widen further by default — sibling stories under a shared epic, or unrelated epics, only if a comment or link in the entry tree points at them.
 
 ## Think Broader
 
-**For PRs, consider:**
-- Are there commits **after** the last review? Alert user if so.
-- What's the review status? Are CI checks passing?
+**For PRs:**
+- Commits **after** the last review? Alert the user.
+- Review status, CI checks, merge-readiness.
 
-**For JIRA tickets, consider:**
-- Is this a **subtask**? Read the parent Story/Epic for bigger picture.
-- Are there **sibling tasks** that provide context?
-- What do the comments reveal about decisions made?
+**For tickets:**
+- What do comments across the hierarchy reveal about decisions and blockers?
+- Is this blocked by a sibling or parent that hasn't moved?
 
 ## What to Surface
 
-Don't just list fields. Provide **insights**:
-- "This subtask is part of [Story] which aims to [goal]"
-- "PR is approved and CI passing - ready to merge"
+Don't list fields. Provide **insights**:
+- "This subtask is part of [Story] which aims to [goal] under Epic [X]"
+- "PR is approved and CI passing — ready to merge"
 - "Blocked: waiting on review from @reviewer"
 
-Start with the most actionable insight. Suggest logical next action.
+Start with the most actionable insight. Suggest the logical next action.


### PR DESCRIPTION
## Why

`codery-status` loaded JIRA context asymmetrically: entering on a Story pulled subtasks, but entering on a Subtask did not pull the parent Story or Epic, and the Epic level was rarely loaded at all. Same ticket tree, different quality of context depending on entry point. The hierarchy-walking guidance lived as a soft suggestion inside *Think Broader* rather than a rule the skill had to follow.

## What

- New **Load the Hierarchy** section in `codery-status` SKILL.md as a hard rule: from any entry point, load every ancestor up to the root, plus the entry's immediate context (children if it has any, otherwise siblings).
- Per-entry-point table makes the smart-walk concrete:
  - Subtask → parent Story + Epic + sibling subtasks
  - Story → Epic + child subtasks
  - Epic → child Stories (skip the subtask layer unless something points there)
- Comments now read on **every** loaded node, not just the entry.
- *Think Broader* trimmed to interpretive guidance only (post-review commits, review status, blockers).
- "Don't widen further by default" guards against pulling sibling stories under a shared epic unless a comment or link in the entry tree points there.

## Evidence

- `codery build` regenerated `.claude/skills/codery-status/SKILL.md`; `diff` against source returns clean (MATCH).
- CRK pass via `advisor()` caught a prose/table inconsistency in the first draft — original "walk to root and back down one level" implied loading sibling stories under a shared epic, contradicting both the table and the explicitly excluded scope. Reworded to "load every ancestor up to the root, plus the entry's immediate context — children if it has any, otherwise siblings" before commit.
- End-to-end behavior on a real subtask not exercised in this run by design (per Mirror gate); observable on next `/codery-status` invocation against any subtask.

## How to Verify

1. Pull this branch, run `npx codery build`.
2. Diff `.claude/skills/codery-status/SKILL.md` against `codery-docs/.codery/skills/codery-status/SKILL.md` — should be identical.
3. Invoke `/codery-status COD-XX` on a Subtask in any Codery-enabled project; observe parent Story, Epic, sibling subtasks, and their comments all loaded.
4. Repeat with a Story ID and an Epic ID; observe loads per the table.

## Reviewer Guidance

This is a behavior change for the AI agent that consumes the skill, not for human users — there's no UI or test surface to assert against. The acceptance criteria on COD-60 are observational and will be exercised the next time you ask Claude to run `/codery-status` on something nested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)