### PR TITLE
feat(build): hub-and-spoke documentation loading (COD-61)

### DIFF
--- a/.codery/config.json
+++ b/.codery/config.json
@@ -5,5 +5,6 @@
   "applicationDocs": [
     "engineering-docs/README.md",
     "engineering-docs/commit-conventions.md"
-  ]
+  ],
+  "jiraIntegrationType": "cli"
 }

--- a/codery-docs/.codery/claude-md-template.md
+++ b/codery-docs/.codery/claude-md-template.md
@@ -93,3 +93,5 @@ Mirror → Scout → Architect → CRK → Builder → Kanban → User Approval
 @.codery/refs/jira-reference.md
 @.codery/refs/git-workflow.md
 {{applicationDocsImports}}
+{{documentationRootImports}}
+{{docsHubBlock}}

--- a/engineering-docs/README.md
+++ b/engineering-docs/README.md
@@ -89,6 +89,17 @@ Codery follows the npm principle: **track inputs, ignore outputs**.
 
 ## Version History
 
+### Version 8.x - Hub-and-Spoke Documentation Loading (COD-61)
+- Added `documentationRoots: string[]` config field for hub-and-spoke doc loading
+- Each entry is a path to an eagerly-loaded "hub" doc; Codery generates `.codery/refs/docs-index.md` listing every `.md` file under the hub's parent folder for on-demand discovery
+- Generated index is `@`-imported by `CLAUDE.md` alongside a principle-driven instruction telling Claude to consult the index proactively when work intersects a documented topic
+- `applicationDocs` is unchanged — it stays the slot for small must-load files
+- Solves the problem of single large doc files (>40k chars) bloating every Claude conversation; teams can split docs and let Claude load on demand
+- Validation: `documentationRoots` entries must point to existing `.md` files (strict at `codery config set` / interactive menu); build is lenient — warns and skips missing entries
+- Tree walk skips `node_modules`, dotfiles, dotdirs, and symlinks; index uses POSIX paths
+- Stale `docs-index.md` from previous builds is removed when `documentationRoots` becomes empty
+- Matches the existing `applicationDocs` pattern in `codery init` (no prompt — initialized to empty array, managed via `codery config`)
+
 ### Version 8.x - `codery config` Command (COD-59)
 - Added `codery config` for viewing and editing `.codery/config.json` without re-running `codery init`
 - Bare `codery config` opens an interactive arrow-key navigable menu listing all fields with current values; select to edit, with appropriate prompt per field type (list / input / array submenu)

--- a/src/lib/buildDocs.ts
+++ b/src/lib/buildDocs.ts
@@ -41,8 +41,12 @@ function substituteTemplates(
   const templateRegex = /\{\{(\w+(?:\.\w+)*)\}\}/g;
 
   const substitutedContent = content.replace(templateRegex, (match, variable) => {
-    // Skip the applicationDocsImports placeholder — handled separately
-    if (variable === 'applicationDocsImports') {
+    // Skip block-level placeholders — handled separately
+    if (
+      variable === 'applicationDocsImports' ||
+      variable === 'documentationRootImports' ||
+      variable === 'docsHubBlock'
+    ) {
       return match;
     }
 
@@ -73,6 +77,188 @@ function generateAppDocsImports(config: CoderyConfig): string {
   return config.applicationDocs
     .map(docPath => `@${docPath}`)
     .join('\n');
+}
+
+// Replace a block-level placeholder in template content. When value is empty
+// and the placeholder sits on its own line, remove the line entirely so we do
+// not leave behind orphan whitespace.
+function substituteBlockPlaceholder(content: string, placeholder: string, value: string): string {
+  if (value !== '') {
+    return content.replace(placeholder, value);
+  }
+  const escaped = placeholder.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const linePattern = new RegExp(`^${escaped}[\\t ]*\\r?\\n?`, 'm');
+  if (linePattern.test(content)) {
+    return content.replace(linePattern, '');
+  }
+  return content.replace(placeholder, '');
+}
+
+// Generate @import lines for documentationRoots entry files. Missing files are
+// warned and skipped so a stale path does not abort the build.
+function generateDocRootImports(config: CoderyConfig, log: (...args: unknown[]) => void): string {
+  if (!config.documentationRoots || config.documentationRoots.length === 0) {
+    return '';
+  }
+  const lines: string[] = [];
+  for (const entryPath of config.documentationRoots) {
+    const resolved = path.resolve(process.cwd(), entryPath);
+    if (!fs.existsSync(resolved)) {
+      log(chalk.yellow(`  ⚠️  documentationRoots entry not found, skipping: ${entryPath}`));
+      continue;
+    }
+    lines.push(`@${entryPath}`);
+  }
+  return lines.join('\n');
+}
+
+// Generate the hub-and-spoke instruction block plus the @import for the
+// generated docs index. Empty when no documentationRoots are configured.
+function generateDocsHubBlock(config: CoderyConfig): string {
+  if (!config.documentationRoots || config.documentationRoots.length === 0) {
+    return '';
+  }
+  return [
+    '',
+    '---',
+    '',
+    '## Project Documentation',
+    '',
+    'Documentation hub-and-spoke. The eagerly-loaded entry docs above are curated reading. The full file tree under each documentation root is at `.codery/refs/docs-index.md` and is loaded into context below.',
+    '',
+    'Treat that index as a first-class lookup. Whenever your current work intersects a topic the tree covers — files you are editing, code you are investigating, design decisions, unfamiliar areas — Read the relevant doc *before* proceeding. The user may not name the topic; you are responsible for noticing.',
+    '',
+    '@.codery/refs/docs-index.md',
+  ].join('\n');
+}
+
+// POSIX-normalize a path string (use forward slashes regardless of platform).
+function toPosix(p: string): string {
+  return p.split(path.sep).join('/');
+}
+
+// Walk a directory recursively and return all .md file paths (relative to
+// projectRoot, POSIX-normalized). Skips dotfiles/dotdirs, node_modules, and
+// symlinks to avoid runaway traversal.
+function walkMarkdownFiles(rootDir: string, projectRoot: string): string[] {
+  const results: string[] = [];
+  if (!fs.existsSync(rootDir)) return results;
+  const queue: string[] = [rootDir];
+  while (queue.length > 0) {
+    const dir = queue.shift() as string;
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      if (entry.isSymbolicLink()) continue;
+      if (entry.name.startsWith('.')) continue;
+      if (entry.name === 'node_modules') continue;
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        queue.push(fullPath);
+        continue;
+      }
+      if (entry.isFile() && entry.name.toLowerCase().endsWith('.md')) {
+        results.push(toPosix(path.relative(projectRoot, fullPath)));
+      }
+    }
+  }
+  return results.sort();
+}
+
+// Build the markdown body for .codery/refs/docs-index.md. Returns null when no
+// documentationRoots are configured (signals the index file should be removed).
+function generateDocsIndexContent(config: CoderyConfig): string | null {
+  if (!config.documentationRoots || config.documentationRoots.length === 0) {
+    return null;
+  }
+  const projectRoot = process.cwd();
+
+  // Files already in CLAUDE.md context — exclude them from the on-demand list.
+  const excluded = new Set<string>();
+  for (const p of config.applicationDocs ?? []) excluded.add(toPosix(p));
+  for (const p of config.documentationRoots) excluded.add(toPosix(p));
+
+  // Group entry files by their parent folder so multiple roots in the same
+  // folder collapse into one section.
+  const groups = new Map<string, string[]>();
+  for (const entryPath of config.documentationRoots) {
+    const resolved = path.resolve(projectRoot, entryPath);
+    if (!fs.existsSync(resolved)) continue;
+    const parentRel = toPosix(path.relative(projectRoot, path.dirname(resolved))) || '.';
+    const list = groups.get(parentRel) ?? [];
+    list.push(toPosix(entryPath));
+    groups.set(parentRel, list);
+  }
+
+  if (groups.size === 0) {
+    return null;
+  }
+
+  const sections: string[] = [
+    '# Project Documentation Index',
+    '',
+    'Generated by `codery build`. Lists every `.md` file under each documentation root. Read these on demand using the Read tool when your work intersects their topics — entry docs are already eagerly loaded into CLAUDE.md.',
+    '',
+  ];
+
+  const sortedGroups = Array.from(groups.entries()).sort(([a], [b]) => a.localeCompare(b));
+  for (const [parentRel, entryPaths] of sortedGroups) {
+    sections.push(`## ${parentRel}/`);
+    sections.push('');
+    sections.push(`Entry doc${entryPaths.length > 1 ? 's' : ''} (eagerly loaded):`);
+    for (const e of entryPaths.sort()) sections.push(`- ${e}`);
+    sections.push('');
+
+    const parentAbs = path.resolve(projectRoot, parentRel);
+    const allMd = walkMarkdownFiles(parentAbs, projectRoot).filter(p => !excluded.has(p));
+    if (allMd.length === 0) {
+      sections.push('_No additional docs in this root._');
+    } else {
+      sections.push('Spoke docs:');
+      for (const p of allMd) sections.push(`- ${p}`);
+    }
+    sections.push('');
+  }
+
+  return sections.join('\n');
+}
+
+// Write or remove .codery/refs/docs-index.md based on documentationRoots.
+function writeOrRemoveDocsIndex(
+  config: CoderyConfig | null,
+  dryRun: boolean,
+  log: (...args: unknown[]) => void
+): void {
+  const indexPath = path.join(process.cwd(), '.codery/refs/docs-index.md');
+  const content = config ? generateDocsIndexContent(config) : null;
+
+  if (content === null) {
+    if (fs.existsSync(indexPath)) {
+      if (dryRun) {
+        log(`Would remove stale .codery/refs/docs-index.md`);
+      } else {
+        fs.unlinkSync(indexPath);
+        log(`  ✓ removed stale docs-index.md`);
+      }
+    }
+    return;
+  }
+
+  if (dryRun) {
+    log(`Would write .codery/refs/docs-index.md`);
+    return;
+  }
+
+  const refsDir = path.dirname(indexPath);
+  if (!fs.existsSync(refsDir)) {
+    fs.mkdirSync(refsDir, { recursive: true });
+  }
+  fs.writeFileSync(indexPath, content, 'utf-8');
+  log(`  ✓ docs-index.md`);
 }
 
 // Get the appropriate git workflow source file based on config
@@ -259,13 +445,21 @@ export async function buildCommand(options: BuildOptions): Promise<void> {
 
     let claudeContent = fs.readFileSync(templatePath, 'utf-8');
 
-    // Inject applicationDocs @imports
-    if (config) {
-      const appDocsImports = generateAppDocsImports(config);
-      claudeContent = claudeContent.replace('{{applicationDocsImports}}', appDocsImports);
-    } else {
-      claudeContent = claudeContent.replace('{{applicationDocsImports}}', '');
-    }
+    // Inject block-level placeholders before the general substitution pass.
+    const appDocsImports = config ? generateAppDocsImports(config) : '';
+    const docRootImports = config ? generateDocRootImports(config, log) : '';
+    const docsHubBlock = config ? generateDocsHubBlock(config) : '';
+    claudeContent = substituteBlockPlaceholder(
+      claudeContent,
+      '{{applicationDocsImports}}',
+      appDocsImports
+    );
+    claudeContent = substituteBlockPlaceholder(
+      claudeContent,
+      '{{documentationRootImports}}',
+      docRootImports
+    );
+    claudeContent = substituteBlockPlaceholder(claudeContent, '{{docsHubBlock}}', docsHubBlock);
 
     // Apply template variable substitution
     let allUnsubstituted: string[] = [];
@@ -292,6 +486,7 @@ export async function buildCommand(options: BuildOptions): Promise<void> {
       log(`File size: ~${Math.round(claudeContent.length / 1024)}KB`);
       log();
       copyReferenceFiles(config, true, options.quiet);
+      writeOrRemoveDocsIndex(config, true, log);
       copySkillFiles(config, true, options.quiet);
       return;
     }
@@ -328,6 +523,7 @@ export async function buildCommand(options: BuildOptions): Promise<void> {
     log();
     log('Copying reference files...');
     copyReferenceFiles(config, false, options.quiet);
+    writeOrRemoveDocsIndex(config, false, log);
 
     // Copy skills to .claude/skills/
     log();

--- a/src/lib/buildDocs.ts
+++ b/src/lib/buildDocs.ts
@@ -68,14 +68,15 @@ function substituteTemplates(
   return { content: substitutedContent, unsubstituted };
 }
 
-// Generate @import lines for applicationDocs
+// Generate @import lines for applicationDocs. POSIX-normalized so configs
+// authored on Windows render usable @-imports cross-platform.
 function generateAppDocsImports(config: CoderyConfig): string {
   if (!config.applicationDocs || config.applicationDocs.length === 0) {
     return '';
   }
 
   return config.applicationDocs
-    .map(docPath => `@${docPath}`)
+    .map(docPath => `@${toPosix(docPath)}`)
     .join('\n');
 }
 
@@ -94,28 +95,51 @@ function substituteBlockPlaceholder(content: string, placeholder: string, value:
   return content.replace(placeholder, '');
 }
 
-// Generate @import lines for documentationRoots entry files. Missing files are
-// warned and skipped so a stale path does not abort the build.
-function generateDocRootImports(config: CoderyConfig, log: (...args: unknown[]) => void): string {
+// POSIX-normalize a path string. Replaces backslashes explicitly so configs
+// authored on Windows render usable @-imports regardless of which platform
+// runs `codery build`.
+function toPosix(p: string): string {
+  return p.replace(/\\/g, '/');
+}
+
+interface ResolvedDocRoot {
+  entryPath: string; // original path string from config
+  resolvedAbs: string; // absolute filesystem path after resolution
+}
+
+// Resolve every documentationRoots entry against the working directory.
+// Missing files are warned and dropped so a stale path does not abort the
+// build. Every downstream generator gates on the returned list — when nothing
+// resolves we emit no imports, no hub block, and no index file (avoids
+// leaving CLAUDE.md with a dangling @.codery/refs/docs-index.md import).
+function resolveDocRoots(
+  config: CoderyConfig,
+  log: (...args: unknown[]) => void
+): ResolvedDocRoot[] {
   if (!config.documentationRoots || config.documentationRoots.length === 0) {
-    return '';
+    return [];
   }
-  const lines: string[] = [];
+  const resolved: ResolvedDocRoot[] = [];
   for (const entryPath of config.documentationRoots) {
-    const resolved = path.resolve(process.cwd(), entryPath);
-    if (!fs.existsSync(resolved)) {
+    const resolvedAbs = path.resolve(process.cwd(), entryPath);
+    if (!fs.existsSync(resolvedAbs)) {
       log(chalk.yellow(`  ⚠️  documentationRoots entry not found, skipping: ${entryPath}`));
       continue;
     }
-    lines.push(`@${entryPath}`);
+    resolved.push({ entryPath, resolvedAbs });
   }
-  return lines.join('\n');
+  return resolved;
+}
+
+// Generate @import lines for resolved documentationRoots entry files.
+function generateDocRootImports(resolved: ResolvedDocRoot[]): string {
+  return resolved.map(r => `@${toPosix(r.entryPath)}`).join('\n');
 }
 
 // Generate the hub-and-spoke instruction block plus the @import for the
-// generated docs index. Empty when no documentationRoots are configured.
-function generateDocsHubBlock(config: CoderyConfig): string {
-  if (!config.documentationRoots || config.documentationRoots.length === 0) {
+// generated docs index. Empty when no roots resolved on disk.
+function generateDocsHubBlock(resolved: ResolvedDocRoot[]): string {
+  if (resolved.length === 0) {
     return '';
   }
   return [
@@ -132,14 +156,21 @@ function generateDocsHubBlock(config: CoderyConfig): string {
   ].join('\n');
 }
 
-// POSIX-normalize a path string (use forward slashes regardless of platform).
-function toPosix(p: string): string {
-  return p.split(path.sep).join('/');
-}
+// Names skipped during the spoke walk so common build/dependency outputs do
+// not pollute the generated index when a documentationRoots entry sits near
+// the project root. Dotfiles/dotdirs are skipped separately.
+const WALK_SKIP_DIRS = new Set([
+  'node_modules',
+  'dist',
+  'build',
+  'out',
+  'target',
+  'coverage',
+]);
 
 // Walk a directory recursively and return all .md file paths (relative to
-// projectRoot, POSIX-normalized). Skips dotfiles/dotdirs, node_modules, and
-// symlinks to avoid runaway traversal.
+// projectRoot, POSIX-normalized). Skips dotfiles/dotdirs, common output
+// directories, and symlinks to avoid runaway traversal.
 function walkMarkdownFiles(rootDir: string, projectRoot: string): string[] {
   const results: string[] = [];
   if (!fs.existsSync(rootDir)) return results;
@@ -155,7 +186,7 @@ function walkMarkdownFiles(rootDir: string, projectRoot: string): string[] {
     for (const entry of entries) {
       if (entry.isSymbolicLink()) continue;
       if (entry.name.startsWith('.')) continue;
-      if (entry.name === 'node_modules') continue;
+      if (WALK_SKIP_DIRS.has(entry.name)) continue;
       const fullPath = path.join(dir, entry.name);
       if (entry.isDirectory()) {
         queue.push(fullPath);
@@ -169,10 +200,13 @@ function walkMarkdownFiles(rootDir: string, projectRoot: string): string[] {
   return results.sort();
 }
 
-// Build the markdown body for .codery/refs/docs-index.md. Returns null when no
-// documentationRoots are configured (signals the index file should be removed).
-function generateDocsIndexContent(config: CoderyConfig): string | null {
-  if (!config.documentationRoots || config.documentationRoots.length === 0) {
+// Build the markdown body for .codery/refs/docs-index.md. Returns null when
+// no roots resolved on disk (signals the index file should be removed).
+function generateDocsIndexContent(
+  config: CoderyConfig,
+  resolved: ResolvedDocRoot[]
+): string | null {
+  if (resolved.length === 0) {
     return null;
   }
   const projectRoot = process.cwd();
@@ -180,22 +214,16 @@ function generateDocsIndexContent(config: CoderyConfig): string | null {
   // Files already in CLAUDE.md context — exclude them from the on-demand list.
   const excluded = new Set<string>();
   for (const p of config.applicationDocs ?? []) excluded.add(toPosix(p));
-  for (const p of config.documentationRoots) excluded.add(toPosix(p));
+  for (const r of resolved) excluded.add(toPosix(r.entryPath));
 
   // Group entry files by their parent folder so multiple roots in the same
   // folder collapse into one section.
   const groups = new Map<string, string[]>();
-  for (const entryPath of config.documentationRoots) {
-    const resolved = path.resolve(projectRoot, entryPath);
-    if (!fs.existsSync(resolved)) continue;
-    const parentRel = toPosix(path.relative(projectRoot, path.dirname(resolved))) || '.';
+  for (const r of resolved) {
+    const parentRel = toPosix(path.relative(projectRoot, path.dirname(r.resolvedAbs))) || '.';
     const list = groups.get(parentRel) ?? [];
-    list.push(toPosix(entryPath));
+    list.push(toPosix(r.entryPath));
     groups.set(parentRel, list);
-  }
-
-  if (groups.size === 0) {
-    return null;
   }
 
   const sections: string[] = [
@@ -227,14 +255,15 @@ function generateDocsIndexContent(config: CoderyConfig): string | null {
   return sections.join('\n');
 }
 
-// Write or remove .codery/refs/docs-index.md based on documentationRoots.
+// Write or remove .codery/refs/docs-index.md based on resolved roots.
 function writeOrRemoveDocsIndex(
   config: CoderyConfig | null,
+  resolved: ResolvedDocRoot[],
   dryRun: boolean,
   log: (...args: unknown[]) => void
 ): void {
   const indexPath = path.join(process.cwd(), '.codery/refs/docs-index.md');
-  const content = config ? generateDocsIndexContent(config) : null;
+  const content = config ? generateDocsIndexContent(config, resolved) : null;
 
   if (content === null) {
     if (fs.existsSync(indexPath)) {
@@ -446,9 +475,12 @@ export async function buildCommand(options: BuildOptions): Promise<void> {
     let claudeContent = fs.readFileSync(templatePath, 'utf-8');
 
     // Inject block-level placeholders before the general substitution pass.
+    // Resolve documentationRoots once so imports, hub block, and index all
+    // gate on the same resolved set.
     const appDocsImports = config ? generateAppDocsImports(config) : '';
-    const docRootImports = config ? generateDocRootImports(config, log) : '';
-    const docsHubBlock = config ? generateDocsHubBlock(config) : '';
+    const resolvedRoots = config ? resolveDocRoots(config, log) : [];
+    const docRootImports = generateDocRootImports(resolvedRoots);
+    const docsHubBlock = generateDocsHubBlock(resolvedRoots);
     claudeContent = substituteBlockPlaceholder(
       claudeContent,
       '{{applicationDocsImports}}',
@@ -486,7 +518,7 @@ export async function buildCommand(options: BuildOptions): Promise<void> {
       log(`File size: ~${Math.round(claudeContent.length / 1024)}KB`);
       log();
       copyReferenceFiles(config, true, options.quiet);
-      writeOrRemoveDocsIndex(config, true, log);
+      writeOrRemoveDocsIndex(config, resolvedRoots, true, log);
       copySkillFiles(config, true, options.quiet);
       return;
     }
@@ -523,7 +555,7 @@ export async function buildCommand(options: BuildOptions): Promise<void> {
     log();
     log('Copying reference files...');
     copyReferenceFiles(config, false, options.quiet);
-    writeOrRemoveDocsIndex(config, false, log);
+    writeOrRemoveDocsIndex(config, resolvedRoots, false, log);
 
     // Copy skills to .claude/skills/
     log();

--- a/src/lib/configSchema.ts
+++ b/src/lib/configSchema.ts
@@ -1,3 +1,5 @@
+import * as fs from 'fs';
+import * as path from 'path';
 import { CoderyConfig } from '../types/config';
 
 export type ConfigKey = keyof CoderyConfig;
@@ -47,6 +49,22 @@ export function validateNonEmpty(input: string): true | string {
   return true;
 }
 
+export function validateDocumentationRootPath(input: string): true | string {
+  const trimmed = input.trim();
+  if (!trimmed) return 'Path cannot be empty.';
+  if (!trimmed.toLowerCase().endsWith('.md')) {
+    return 'Documentation root must point to a .md file.';
+  }
+  const resolved = path.resolve(process.cwd(), trimmed);
+  if (!fs.existsSync(resolved)) {
+    return `File does not exist: ${trimmed}`;
+  }
+  if (!fs.statSync(resolved).isFile()) {
+    return `Path is not a regular file: ${trimmed}`;
+  }
+  return true;
+}
+
 export const configSchema: Record<ConfigKey, FieldSchema> = {
   projectKey: {
     kind: 'scalar',
@@ -83,6 +101,11 @@ export const configSchema: Record<ConfigKey, FieldSchema> = {
     kind: 'array',
     description: 'Paths to project-specific docs imported into CLAUDE.md',
     itemValidate: validateNonEmpty,
+  },
+  documentationRoots: {
+    kind: 'array',
+    description: 'Paths to hub docs that drive on-demand discovery of spoke files',
+    itemValidate: validateDocumentationRootPath,
   },
 };
 

--- a/src/lib/initCommand.ts
+++ b/src/lib/initCommand.ts
@@ -131,6 +131,8 @@ export async function initCommand(options: InitOptions): Promise<void> {
       jiraIntegrationType: answers.jiraIntegrationType,
       // Preserve applicationDocs if it exists, otherwise initialize as empty
       applicationDocs: existingConfig.applicationDocs || [],
+      // Preserve documentationRoots if it exists, otherwise initialize as empty
+      documentationRoots: existingConfig.documentationRoots || [],
     };
 
     // Only add developBranch for gitflow
@@ -210,6 +212,11 @@ export async function initCommand(options: InitOptions): Promise<void> {
     if (config.applicationDocs && config.applicationDocs.length > 0) {
       console.log(
         `  - Application Docs: ${chalk.cyan(`${config.applicationDocs.length} path(s) preserved`)}`
+      );
+    }
+    if (config.documentationRoots && config.documentationRoots.length > 0) {
+      console.log(
+        `  - Documentation Roots: ${chalk.cyan(`${config.documentationRoots.length} path(s) preserved`)}`
       );
     }
     console.log();

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -3,6 +3,7 @@ export interface CoderyConfig {
   developBranch?: string;
   mainBranch?: string;
   applicationDocs?: string[];
+  documentationRoots?: string[];
   gitWorkflowType?: 'gitflow' | 'trunk-based';
   jiraIntegrationType?: 'mcp' | 'cli';
   jiraCloudId?: string;


### PR DESCRIPTION
## Why

Engineering docs in this project (and others) have grown past 40k characters in single files, triggering Claude Code size warnings. The current `applicationDocs` config eagerly `@`-imports every listed file into `CLAUDE.md`, so growing docs are fully loaded into every conversation. Splitting docs alone doesn't help if the new pieces are still all eagerly imported.

This PR adds a hub-and-spoke loading model so docs can be organized as a curated entry point ("hub") plus topic-specific files ("spokes") that Claude reads on demand instead of preloading.

Linked ticket: [COD-61](https://turalnovruzov.atlassian.net/browse/COD-61)

## What

- **New `documentationRoots: string[]` config field.** Each entry is a path to an eagerly-loaded "hub" doc; Codery generates `.codery/refs/docs-index.md` listing every `.md` file under each root's parent folder for on-demand discovery.
- **`applicationDocs` semantics unchanged.** It stays the slot for small must-load files.
- **Template gains two placeholders.** `claude-md-template.md` now has `{{documentationRootImports}}` and `{{docsHubBlock}}` alongside the existing `{{applicationDocsImports}}`. Hub block expands to a `## Project Documentation` section with a principle-driven instruction telling Claude to consult the index proactively (signals: editing code in a doc-covered domain, encountering unfamiliar code, making design decisions, answering architecture questions) plus an `@.codery/refs/docs-index.md` import.
- **Validation split.** Strict at `codery config set` / interactive menu / `codery config add` (path must be an existing `.md` file); lenient at build time (warns and skips missing entries instead of failing the build).
- **Tree walk hardening.** Skips `node_modules`, dotfiles, dotdirs, and symlinks. Index uses POSIX paths for cross-platform consistency.
- **Stale-state handling.** `docs-index.md` from a previous build is automatically removed when `documentationRoots` becomes empty.
- **Empty array is fully optional.** No imports, no index file, no hub block — backward compatible with all existing configs.
- **Schema-driven config plumbing.** Once registered in `configSchema.ts`, the entire `codery config` surface (get/set/add/remove + interactive menu) Just Works — no changes to `configCommand.ts` or `bin/codery.ts`.
- `engineering-docs/README.md` updated with v8.x version entry.

## Evidence

- `npm run typecheck` — clean
- `npm run build` — clean (`tsc` produces `dist/`)
- `npm run lint` — only pre-existing `no-explicit-any` warnings; none introduced by this change
- `npm run format:check` — flags pre-existing format drift in `buildDocs.ts` and `updateCommand.ts`. Verified the new code is correctly formatted; the drift was present on `main` before this branch (CI does not enforce format)
- **Synthetic dogfood test** in `/tmp/codery-test/` exercised:
  - **Populated `documentationRoots`:** `CLAUDE.md` gets entry import + hub block; `docs-index.md` generated with correct grouping; `applicationDocs` paths and entry files excluded from spoke list; subdirectory files (`sub/deep.md`) included; `node_modules/` and `.hidden/` directories skipped; POSIX paths confirmed.
  - **Empty `documentationRoots`:** stale `docs-index.md` removed by build, hub block absent, no orphan blank lines in `CLAUDE.md`.
  - **Missing entry path:** warning printed (`⚠️  documentationRoots entry not found, skipping: ...`), build continues, valid entries still processed.
  - **`codery config add documentationRoots <bad-path>`:** rejected for non-existent file (`File does not exist: ...`) and for non-`.md` file (`Documentation root must point to a .md file.`).
- `codery config list` confirms the field round-trips through JSON correctly.

## How to Verify

```bash
# Build the package locally
npm install && npm run build

# Set up a sandbox
mkdir -p /tmp/cod61-sandbox/docs/sub /tmp/cod61-sandbox/.codery
cd /tmp/cod61-sandbox
cat > .codery/config.json <<JSON
{
  "projectKey": "TEST",
  "mainBranch": "main",
  "gitWorkflowType": "trunk-based",
  "jiraIntegrationType": "cli",
  "documentationRoots": ["docs/README.md"]
}
JSON
echo "# Hub" > docs/README.md
echo "# Auth" > docs/auth.md
echo "# Deep" > docs/sub/deep.md

# Build and inspect
node /path/to/codery/dist/bin/codery.js build --force
tail -15 CLAUDE.md                  # Hub block + @.codery/refs/docs-index.md
cat .codery/refs/docs-index.md      # docs/auth.md, docs/sub/deep.md as spokes; README.md as entry

# Test strict config validation
node /path/to/codery/dist/bin/codery.js config add documentationRoots docs/missing.md  # Rejects
node /path/to/codery/dist/bin/codery.js config add documentationRoots docs/auth.md     # Accepts

# Test stale cleanup
node /path/to/codery/dist/bin/codery.js config unset documentationRoots
node /path/to/codery/dist/bin/codery.js build --force
ls .codery/refs/docs-index.md       # Should not exist
```

## Reviewer Guidance

- **AC #2 reinterpretation.** The original ticket said `codery init` should prompt for documentation roots. This PR matches the existing `applicationDocs` pattern instead — no init prompt; initialized to empty array; managed via `codery config`. Confirmed with the user during the brainstorm under the directive "just like applicationDocs, you don't have to provide anything." Calling it out here so it doesn't read as a missed AC.
- **No tests added.** The repo has `jest` configured but contains no test files yet. Following the project's existing precedent (recent PRs COD-58, COD-59, COD-60 also shipped without tests). Verification was done end-to-end via the synthetic sandbox described above.
- **Dogfooding deferred.** This project's own `engineering-docs/README.md` is the file that motivated the ticket. Moving it from `applicationDocs` to `documentationRoots` without first splitting it doesn't actually fix the bloat (entry files are still eagerly loaded). Splitting `engineering-docs/README.md` into a hub + spokes is the natural follow-up; deliberately out of scope here to keep this PR focused on the mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — autopilot run, draft until human review.