### PR TITLE
feat(skills): redesign codery-audit as multi-phase audit (COD-62)

### DIFF
--- a/codery-docs/.codery/skills/codery-audit/SKILL.md
+++ b/codery-docs/.codery/skills/codery-audit/SKILL.md
@@ -1,58 +1,101 @@
 ---
-description: Review a PR with linked JIRA context, discuss findings, and generate report. Use when reviewing a PR, auditing code, doing a code review, checking if changes are ready to merge, or getting feedback on implementation before merging.
+description: Multi-phase audit of a PR — acceptance criteria, functional verification, design fidelity, code review. Use when reviewing a PR, auditing code, doing a code review, checking if changes are ready to merge, or getting feedback on implementation before merging.
 argument-hint: <PR-number or ticket-id>
 ---
 
 # Audit
 
-Perform a comprehensive PR review in the main conversation context for iterative discussion.
+Run a comprehensive 4-phase audit on a PR — not just code review. The audit answers four questions in order:
+
+1. **Does this PR satisfy the ticket's acceptance criteria?** (Phase 1)
+2. **Does the feature actually work when run?** (Phase 2)
+3. **Where there's a design source of truth, does the implementation match?** (Phase 3)
+4. **Is the code itself healthy?** (Phase 4)
+
+All phases run regardless of upstream results. Each phase produces findings + a status. The overall verdict is computed from phase statuses combined.
 
 ## Context Loading
 
-**If PR number given**: Fetch PR details + diff, find linked JIRA ticket.
-**If ticket ID given**: Fetch ticket, find linked PR + diff.
-**If no argument**: Check current branch for ticket ID or open PR.
+- **PR number given** → fetch PR diff, find linked JIRA ticket
+- **Ticket ID given** → fetch ticket, find linked PR + diff
+- **No argument** → check current branch for ticket pattern or open PR
 
-## Review Process
+For ticket reading, delegate to `codery-status` when fuller hierarchy context (parent epic, sibling tickets) is needed.
 
-### 1. Requirements Compliance
-Extract requirements from JIRA ticket. Map each to implementation. Flag missing or partial implementations.
+## The Pipeline
 
-### 2. Pattern Comparison
-Find 1-3 prior merged PRs in the same area of the codebase (same feature surface, same framework area, same file type). Use `gh pr list` with relevant filters or `git log` on the target files. Diff the current PR's approach against what was done before:
+Each phase has a focused playbook. Run them in order; do not skip on prior-phase failure.
 
-- Does it follow established naming, structure, and conventions?
-- Does it contradict recent decisions without explanation?
-- Does it introduce a new pattern that should be explicitly justified?
+1. **Phase 1 — Acceptance Criteria.** Follow `phase-1-acceptance.md`.
+2. **Phase 2 — Functional Verification.** Follow `phase-2-verify.md`.
+3. **Phase 3 — Design Fidelity.** Follow `phase-3-design.md`. (`not-applicable` when no design source exists; phase is omitted from the report.)
+4. **Phase 4 — Code Review.** Follow `phase-4-code-review.md`.
 
-If the PR diverges from prior patterns without explicit justification, flag it as a finding.
+Each phase reports a status: `passed` / `partial` / `failed` / `blocked` / `not-applicable`.
 
-### 3. Code Quality Review
-- **Security**: Authentication, authorization, data exposure, injection risks
-- **Performance**: Query efficiency, caching, resource management
-- **Quality**: Readability, naming, error handling, DRY principle
-- **Standards**: Project conventions from CLAUDE.md and application-docs
-- **Tests**: Coverage for new/modified code
+## Verdict Computation
 
-### 4. Present Findings (Private Draft)
-Organize by severity: **Critical** (must fix) → **Recommendations** (should consider) → **Positive Notes** (good patterns). This is a private draft in the conversation — not a GitHub post. Tone: direct, specific, sharp — for the user's review, not public consumption. Do NOT post to GitHub yet.
+One overall verdict, computed from the four phase statuses:
+
+- **`changes-required`** — any phase = `failed`
+- **`cannot-verify`** — any phase = `blocked` and no phase = `failed`
+- **`ready-to-merge`** — every phase that ran is `passed` or `partial` (and at least Phase 4 ran)
+
+`not-applicable` does not contribute to the verdict.
+
+## Consolidated Report (private draft)
+
+After all phases run, present a single private draft to the user. Do not post to GitHub yet. Format:
+
+```text
+# Audit — PR #<n> / <ticket-id>
+
+## Verdict: <READY-TO-MERGE | CHANGES-REQUIRED | CANNOT-VERIFY>
+
+| Phase | Status |
+|---|---|
+| 1. Acceptance Criteria | <status> |
+| 2. Functional Verification | <status> |
+| 3. Design Fidelity | <status or n/a> |
+| 4. Code Review | <status> |
+
+---
+
+[Phase 1 output block]
+
+[Phase 2 output block]
+
+[Phase 3 output block — omitted if not-applicable]
+
+[Phase 4 output block]
+```
+
+Tone for the private draft: direct, specific, sharp — for the user's review, not public consumption.
 
 ## Interactive Discussion
 
-After presenting the private draft, engage in discussion. Answer questions, clarify concerns, discuss alternatives, reach consensus.
+After presenting the draft, discuss with the user. Answer questions, clarify findings, accept pushback where the user has merit, hold firm where code health is at stake. Reach consensus before posting.
 
 ## Posting to GitHub
 
-Only after the user explicitly approves posting (e.g., "post it", "submit", "ready"):
+Only after explicit approval ("post it", "submit", "ready"):
 
-1. **Inline comments by default.** Use `gh api` with the PR review-comment endpoints to attach per-line comments on the specific code locations. Reserve the top-level review body for a brief summary.
-2. **Softer public tone.** Phrase findings as questions or suggestions where appropriate ("Consider extracting..." vs "This should be extracted"). Keep critique specific; strip the private-draft sharpness.
-3. **Approval type.** APPROVE / REQUEST_CHANGES / COMMENT, chosen from finding severity.
+1. **Inline comments by default.** Use `gh api` with PR review-comment endpoints to attach per-line comments at specific code locations. Reserve the top-level review body for a brief summary plus the verdict.
+2. **Severity labels in comments.** Prefix each comment: `Critical:` / `Important:` / `Nit:` / `Optional:` / `Consider:` / `FYI:` / `Praise:`. Phase 1 / 2 / 3 findings can ride in the top-level body when they don't have a single anchor line; Phase 4 findings are inline by default.
+3. **Soften the public tone.** Phrase as questions or suggestions where appropriate ("Consider extracting…" not "This should be extracted"). Strip the private-draft sharpness; preserve specificity.
+4. **Approval type.** APPROVE / REQUEST_CHANGES / COMMENT — choose from the verdict and severity counts.
 
 Never post without explicit approval. Never post the private draft verbatim.
 
-## Final Report
+## After Posting
 
-When user requests ("generate report"), create `reviews/PR-<number>-review.md` with: summary, requirements compliance table, findings by severity, conclusion.
+Mention to the user: "Run `/codery-docs-check` to verify docs are up to date — audits frequently uncover doc drift."
 
-After reviewing, mention: "Run `/codery-docs-check` to verify docs are up to date."
+## Anti-Patterns
+
+- Skipping a phase because a prior one failed
+- Posting the private draft to GitHub without explicit approval
+- Inventing acceptance criteria when the ticket has none (Phase 1 is `not-applicable`, not "lowered bar")
+- Manufacturing test data to make Phase 2 "pass"
+- Critiquing the design itself in Phase 3 — fidelity to source only
+- Flagging things CI catches in Phase 4

--- a/codery-docs/.codery/skills/codery-audit/SKILL.md
+++ b/codery-docs/.codery/skills/codery-audit/SKILL.md
@@ -26,10 +26,10 @@ For ticket reading, delegate to `codery-status` when fuller hierarchy context (p
 
 Each phase has a focused playbook. Run them in order; do not skip on prior-phase failure.
 
-1. **Phase 1 — Acceptance Criteria.** Follow `phase-1-acceptance.md`.
-2. **Phase 2 — Functional Verification.** Follow `phase-2-verify.md`.
-3. **Phase 3 — Design Fidelity.** Follow `phase-3-design.md`. (`not-applicable` when no design source exists; phase is omitted from the report.)
-4. **Phase 4 — Code Review.** Follow `phase-4-code-review.md`.
+1. **Phase 1 — Acceptance Criteria.** Follow [phase-1-acceptance.md](phase-1-acceptance.md).
+2. **Phase 2 — Functional Verification.** Follow [phase-2-verify.md](phase-2-verify.md).
+3. **Phase 3 — Design Fidelity.** Follow [phase-3-design.md](phase-3-design.md). (`not-applicable` when no design source exists; phase is omitted from the report.)
+4. **Phase 4 — Code Review.** Follow [phase-4-code-review.md](phase-4-code-review.md).
 
 Each phase reports a status: `passed` / `partial` / `failed` / `blocked` / `not-applicable`.
 

--- a/codery-docs/.codery/skills/codery-audit/phase-1-acceptance.md
+++ b/codery-docs/.codery/skills/codery-audit/phase-1-acceptance.md
@@ -1,0 +1,67 @@
+# Phase 1 — Acceptance Criteria
+
+**Goal:** Determine whether the PR delivers what the ticket asked for. Answer: does this PR close this ticket?
+
+**Inputs:** linked JIRA ticket (description + AC section + comments), PR diff, PR description.
+
+## Signals — when "AC" exists
+
+- An "Acceptance Criteria" / "AC" / "Done when" section in the ticket body
+- A checklist of testable conditions the ticket explicitly defines as done
+
+What does NOT count as AC:
+
+- A general description ("we should add a button") — that's context, not criteria
+- Inferred requirements from the title alone
+- Bullet points buried in scope/why sections — only an explicit AC section qualifies
+
+Comments that explicitly add or revise AC count if framed as scope changes; otherwise treat as context.
+
+## Principles
+
+- **Strict.** No explicit AC section → phase is `not-applicable`. Do not invent criteria. Lack of AC is a ticket-quality signal, not a reason to lower the bar.
+- **Map, don't restate.** For each requirement, cite the file and line range that delivers it. The mapping is a reusable artifact — Phase 2 uses it as the verification plan.
+- **Don't second-guess the requirements themselves.** That's a ticket conversation, not an audit. Flag ambiguous AC; score against the most plausible reading.
+- **Scope creep is its own finding.** Implementation that goes beyond AC gets flagged separately, never counted as extra credit toward AC.
+
+## Scoring per requirement
+
+- `met` — clear, observable delivery in the diff
+- `partial` — partly delivered, with named gaps
+- `not-met` — required, not delivered
+- `scope-creep` — flagged separately, does not contribute to status
+
+## Phase status
+
+- `passed` — all requirements `met`
+- `partial` — at least one `partial`, no `not-met`
+- `failed` — at least one `not-met`
+- `not-applicable` — no extractable explicit AC
+
+## Anti-patterns
+
+- Manufacturing AC from the description when no AC section exists
+- Lowering the bar because the ticket is sparse
+- Demanding things the AC doesn't ask for
+- Treating scope creep as a positive
+
+## Output for the consolidated report
+
+```text
+Phase 1 — Acceptance Criteria: <STATUS>
+
+  ✅ Met (N):
+    - <requirement> → file:line-range
+
+  ⚠️  Partial (N):
+    - <requirement> → file:line-range
+      Gap: <what's missing>
+
+  ❌ Not met (N):
+    - <requirement>
+      Reason: <why>
+
+  📦 Scope creep (N):
+    - <what was added> → file:line-range
+      Intentional? <flag for discussion>
+```

--- a/codery-docs/.codery/skills/codery-audit/phase-2-verify.md
+++ b/codery-docs/.codery/skills/codery-audit/phase-2-verify.md
@@ -1,0 +1,74 @@
+# Phase 2 — Functional Verification
+
+**Goal:** Run the thing. Confirm it does what it claims to do — not just that the code reads correctly.
+
+**Inputs:** Phase 1's requirement → file mapping (the test plan), PR diff (for diff-driven probes), available tools (`gh`, `curl`, dev-server scripts, Playwright MCP, project test commands).
+
+## Signals — what to verify
+
+- Each requirement scored `met` or `partial` in Phase 1 → derive a verification scenario for it
+- New tests added by the PR → run them
+- Diff-touched code paths not covered by AC → probe quickly for regression
+
+If Phase 1 reported `not-applicable`, fall back to: verify the PR's stated changes work as described in its own description.
+
+## Principles
+
+- **Cheapest credible verification per scenario.** Existing tests cover it → run them. CLI command → run it. API endpoint → `curl` / `gh api`. UI flow → Playwright. Complex / auth-gated / external → manual handoff.
+- **Evidence convention.** For each scenario: `Ran X. Observed Y. Expected Z. Match | mismatch.` Same shape Builder/Executor use elsewhere.
+- **Never fabricate test data.** No mock setup, no fake fixtures, no production-data shortcuts. If verification needs realistic data the env doesn't have, that's a manual handoff.
+- **Never run destructive operations** (drops, deletes, prod writes, `rm -rf`, `git reset --hard`) without explicit user confirmation. Defer to standard destructive-action rules.
+- **Punt and continue.** When a scenario can't run (auth, env, complex setup), produce a manual handoff, mark the scenario `awaiting-manual`, and continue. Don't block the audit.
+
+## Manual handoff format
+
+When the model can't verify a scenario itself:
+
+```text
+🧪 Manual verification needed: <scenario>
+   Why: <auth / env / external service / hardware / etc.>
+   Steps:
+     1. <concrete step>
+     2. <concrete step>
+   Expected: <what success looks like>
+   Reply with the result and the audit will incorporate it.
+```
+
+## Phase status
+
+- `passed` — every scenario verified, every result matched
+- `partial` — some scenarios verified-OK, some `awaiting-manual` (none failed)
+- `failed` — at least one scenario verified-broken
+- `blocked` — nothing could be run (build failed, no env, missing deps); Phase 4 falls back to static-only review and notes the gap
+
+## Anti-patterns
+
+- Reading code and declaring it "works" without running anything
+- Mocking up data to make a verification "pass"
+- Running destructive operations to "test" them
+- Marking the whole phase `blocked` because one scenario needs manual — punt that one, verify the rest
+
+## Output for the consolidated report
+
+```text
+Phase 2 — Functional Verification: <STATUS>
+
+  ✅ Verified (N):
+    - <scenario>
+      Ran: <command/action>
+      Observed: <result>
+      Match.
+
+  🧪 Awaiting manual (N):
+    - <scenario>
+      [handoff block]
+
+  ❌ Verified broken (N):
+    - <scenario>
+      Ran: <command/action>
+      Observed: <result>
+      Expected: <expected>
+      Diagnosis: <brief>
+
+  ⚠️  Blocked: <reason>     (only when status = blocked)
+```

--- a/codery-docs/.codery/skills/codery-audit/phase-3-design.md
+++ b/codery-docs/.codery/skills/codery-audit/phase-3-design.md
@@ -1,0 +1,56 @@
+# Phase 3 — Design Fidelity
+
+**Goal:** Where a design source of truth exists, verify the implementation matches it.
+
+**Inputs:** linked JIRA ticket, PR description, PR diff, design tools (Figma MCP if available).
+
+## Signals — when this phase applies
+
+A "design source of truth" is anything the team committed to as the spec for what this work should look like. Concretely:
+
+- A Figma file linked in the JIRA ticket or the PR description
+- A mockup image attached to the ticket or PR
+- A design document (annotated screenshots, component spec, design ADR) referenced from the ticket or PR
+- A design system component the PR claims to implement against
+
+If none of these exist for this work, the phase is `not-applicable` and is omitted from the consolidated report. Do not manufacture a design source.
+
+## Principles
+
+- **Compare what the diff produces to what the source describes.** Use Figma MCP to read the source when available; otherwise compare against the image or document.
+- **Focus on observable fidelity.** Layout, spacing, typography, color, component states (loading / empty / error / success), interaction affordances. Don't critique the design itself.
+- **Surface mismatches as concrete findings.** "Button is `bg-slate-700` in code; design uses `bg-slate-800`" — addressable, not opinion.
+- **Acknowledge intentional deviations.** If the PR description explains a deviation from the design, accept it; don't re-litigate.
+
+## Phase status
+
+- `passed` — implementation matches source on every dimension checked
+- `partial` — minor mismatches (small spacing, near-color shifts) but overall intent preserved
+- `failed` — significant mismatch (missing states, wrong layout, wrong components)
+- `not-applicable` — no design source of truth identified; phase is omitted from the report
+
+## Anti-patterns
+
+- Inventing a design source from the description when none was linked
+- Critiquing the design itself ("this should be a different color")
+- Treating implementation choices unrelated to design (variable names, file structure) as fidelity issues
+
+## Output for the consolidated report
+
+When `not-applicable`, the phase is omitted entirely. When it ran:
+
+```text
+Phase 3 — Design Fidelity: <STATUS>
+
+Source: <Figma URL / mockup / design doc>
+
+  ✅ Matches (N):
+    - <dimension>: <evidence>
+
+  ⚠️  Minor mismatch (N):
+    - <dimension>: <implementation> vs <source>
+
+  ❌ Mismatch (N):
+    - <dimension>: <implementation> vs <source>
+      Why it matters: <impact>
+```

--- a/codery-docs/.codery/skills/codery-audit/phase-4-code-review.md
+++ b/codery-docs/.codery/skills/codery-audit/phase-4-code-review.md
@@ -1,0 +1,100 @@
+# Phase 4 — Code Review
+
+**Goal:** Improve overall code health. Not perfect — *better*.
+
+> "There is no such thing as 'perfect' code — there is only better code. Reviewers should favor approving a CL once it is in a state where it definitely improves the overall code health of the system being worked on, even if the CL isn't perfect." — Google's Code Review Standard
+
+**Inputs:** PR diff, prior PRs in the same area (1–3 for pattern comparison), `CLAUDE.md` and applicable doc imports for project conventions, code comments in modified files.
+
+## Navigation — how to read the diff
+
+1. **Broad view first.** Does the change make sense at all? If the design is fundamentally wrong, surface that first — don't bury it under nits.
+2. **Main components next.** Largest logical changes. Architecture concerns surface here; flag them before the author builds more on top.
+3. **Systematic line review last.** Once design and architecture are sound, walk every modified line at appropriate depth.
+
+## The 12 things to look for
+
+- **Design** — interactions of new code with the rest of the system; does this belong here?
+- **Functionality** — does it solve the actual problem; edge cases; concurrency; user-visible impact
+- **Complexity** — over-engineering, speculative future-proofing, unnecessary abstractions; reject "solving problems we don't have"
+- **Tests** — present, correct, sufficient; assertions actually fail when the code breaks
+- **Naming** — clear, communicative, appropriately sized; no cryptic abbreviations
+- **Comments** — explain *why*, not *what*; remove rotted ones; require code clarity over commentary
+- **Style** — conformance to project style; use `Nit:` for personal-preference nudges
+- **Consistency** — matches surrounding code unless there's a reason; new patterns require justification
+- **Documentation** — README / docs / changelog / `CLAUDE.md` updated when behavior changes
+- **Every Line** — understand the change at appropriate depth; ask for clarification rather than assuming
+- **Context** — fit with the broader system; cumulative complexity; degradation
+- **Good Things** — name what was done well; reinforcement is part of review
+
+## Pattern comparison
+
+For each substantial diff area, find 1–3 prior merged PRs in the same surface (`gh pr list`, `git log` on touched files). Diff the new approach against the old:
+
+- Does it follow established naming, structure, conventions?
+- Does it contradict recent decisions without explanation?
+- Does it introduce a new pattern without justifying why?
+
+Divergence without justification is a finding.
+
+## Severity labels
+
+Adopt Google's conventions plus a few extras for this audit's needs:
+
+- **Critical** — must fix before merge; bug, security issue, data loss risk, broken functionality
+- **Important** — should fix before merge; architecture problems, missing error handling, test gaps that matter
+- **`Nit:`** — minor, technically should be addressed; non-blocking
+- **`Optional:`** / **`Consider:`** — suggestion without expectation; author's call
+- **`FYI:`** — informational; no action expected
+- **`Praise:`** — call out good work; reinforcement, not flattery
+
+## Don't flag (false-positive guardrails)
+
+- Pre-existing issues outside the diff
+- Things a linter / typechecker / CI catches automatically
+- General code-quality complaints not tied to the PR's actual changes
+- Style preferences not in the project's style guide
+- Stuff already silenced intentionally (`// eslint-disable`, `# noqa`, etc.)
+- Real issues on lines the PR didn't modify
+
+## Principles
+
+- **Code health > perfection.** Approve when the system gets better, even if not ideal.
+- **Address the code, not the developer.** "The concurrency model adds complexity without performance benefit" — not "Why did you do this?"
+- **Explain reasoning.** Reference the principle, the doc, or the prior PR.
+- **Push back where warranted.** "Improving code health happens in small steps" — don't accept "clean it up later" for new complexity.
+- **Concede where warranted.** Author often knows their code better; technical merit wins.
+
+## Phase status
+
+Computed from severity counts:
+
+- `failed` — any `Critical`
+- `partial` — any `Important`, no `Critical`
+- `passed` — only `Nit` / `Optional` / `Praise` or empty
+
+## Output for the consolidated report
+
+Group by severity, descending:
+
+```text
+Phase 4 — Code Review: <STATUS>
+
+  Critical (N):
+    - file:line-range — <issue>
+      Why it matters: <impact>
+      Fix: <how to address>
+
+  Important (N):
+    - file:line-range — <issue>
+      Why it matters: <impact>
+
+  Nit (N):
+    - file:line-range — <suggestion>
+
+  Optional / Consider (N):
+    - file:line-range — <suggestion>
+
+  Praise (N):
+    - file:line-range — <what's good>
+```

--- a/src/lib/buildDocs.ts
+++ b/src/lib/buildDocs.ts
@@ -374,7 +374,90 @@ function copyReferenceFiles(
   }
 }
 
-// Copy skill files to .claude/skills/ directory with substitution
+// Recursively list every file under a skill source dir, returning
+// POSIX-normalized paths relative to that root. Skips dotfiles, dotdirs, and
+// symlinks. Used by both the dry-run preview and the recursive copy.
+function listSkillFiles(sourceRoot: string): string[] {
+  const results: string[] = [];
+  const queue: string[] = [sourceRoot];
+  while (queue.length > 0) {
+    const dir = queue.shift() as string;
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      if (entry.isSymbolicLink()) continue;
+      if (entry.name.startsWith('.')) continue;
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        queue.push(fullPath);
+        continue;
+      }
+      if (entry.isFile()) {
+        results.push(toPosix(path.relative(sourceRoot, fullPath)));
+      }
+    }
+  }
+  return results.sort();
+}
+
+// Copy a single skill directory tree to its target. Applies {{var}}
+// substitution to .md files; copies other extensions verbatim. Warns and
+// continues on per-file errors so one bad file does not break the build.
+function copySkillDirectory(
+  source: string,
+  target: string,
+  config: CoderyConfig | null,
+  log: (...args: unknown[]) => void,
+  skillName: string
+): void {
+  const files = listSkillFiles(source);
+  if (files.length === 0) {
+    log(chalk.yellow(`  ⚠️  ${skillName}/ has no files`));
+    return;
+  }
+
+  for (const relPath of files) {
+    const sourceFile = path.join(source, relPath);
+    const targetFile = path.join(target, relPath);
+
+    try {
+      const targetSubdir = path.dirname(targetFile);
+      if (!fs.existsSync(targetSubdir)) {
+        fs.mkdirSync(targetSubdir, { recursive: true });
+      }
+
+      if (relPath.toLowerCase().endsWith('.md')) {
+        let content = fs.readFileSync(sourceFile, 'utf-8');
+        if (config) {
+          const result = substituteTemplates(content, config);
+          content = result.content;
+          if (result.unsubstituted.length > 0) {
+            log(
+              chalk.yellow(
+                `  ⚠️  Unsubstituted in ${skillName}/${relPath}: ${result.unsubstituted.join(', ')}`
+              )
+            );
+          }
+        }
+        fs.writeFileSync(targetFile, content, 'utf-8');
+      } else {
+        fs.copyFileSync(sourceFile, targetFile);
+      }
+      log(`  ✓ ${skillName}/${relPath}`);
+    } catch (err: any) {
+      log(chalk.yellow(`  ⚠️  Failed to copy ${skillName}/${relPath}: ${err.message}`));
+    }
+  }
+}
+
+// Copy skill directories to .claude/skills/ with substitution. Each skill is
+// a directory containing SKILL.md and any companion files (phase playbooks,
+// templates, etc.). Companion files are required for skills that reference
+// them by name from SKILL.md.
 function copySkillFiles(
   config: CoderyConfig | null,
   dryRun: boolean = false,
@@ -390,7 +473,6 @@ function copySkillFiles(
   }
 
   try {
-    // Get all skill directories
     const skillDirs = fs.readdirSync(sourceDir)
       .filter(item => fs.statSync(path.join(sourceDir, item)).isDirectory());
 
@@ -400,39 +482,19 @@ function copySkillFiles(
 
     if (dryRun) {
       log(`Would copy ${skillDirs.length} skills to ${targetDir}`);
-      skillDirs.forEach(dir => log(`  - ${dir}/SKILL.md`));
+      for (const skillDir of skillDirs) {
+        const files = listSkillFiles(path.join(sourceDir, skillDir));
+        for (const f of files) log(`  - ${skillDir}/${f}`);
+      }
       return true;
     }
 
     log(`Copying ${skillDirs.length} skills...`);
 
     for (const skillDir of skillDirs) {
-      const sourcePath = path.join(sourceDir, skillDir, 'SKILL.md');
-      const targetSkillDir = path.join(targetDir, skillDir);
-      const targetPath = path.join(targetSkillDir, 'SKILL.md');
-
-      if (!fs.existsSync(sourcePath)) {
-        continue;
-      }
-
-      // Create skill directory
-      if (!fs.existsSync(targetSkillDir)) {
-        fs.mkdirSync(targetSkillDir, { recursive: true });
-      }
-
-      // Read, substitute, write
-      let content = fs.readFileSync(sourcePath, 'utf-8');
-      if (config) {
-        const result = substituteTemplates(content, config);
-        content = result.content;
-
-        if (result.unsubstituted.length > 0) {
-          log(chalk.yellow(`  ⚠️  Unsubstituted in ${skillDir}: ${result.unsubstituted.join(', ')}`));
-        }
-      }
-
-      fs.writeFileSync(targetPath, content, 'utf-8');
-      log(`  ✓ ${skillDir}/SKILL.md`);
+      const skillSource = path.join(sourceDir, skillDir);
+      const skillTarget = path.join(targetDir, skillDir);
+      copySkillDirectory(skillSource, skillTarget, config, log, skillDir);
     }
 
     return true;


### PR DESCRIPTION
## Why

The existing `codery-audit` skill only checks code quality. Real audits — especially in a small team where one reviewer covers code-review + QA + design + product-acceptance — also need to verify (a) the PR satisfies the JIRA acceptance criteria, (b) the feature actually works when run, and (c) where relevant, the implementation matches the design source of truth. Code quality is the last layer, not the only layer.

## What

- Restructure `codery-audit` from a single SKILL.md into a thin orchestrator + 4 focused phase playbooks: `phase-1-acceptance.md`, `phase-2-verify.md`, `phase-3-design.md`, `phase-4-code-review.md`
- All phases run regardless of upstream status; per-phase status combined into one verdict (`ready-to-merge` / `changes-required` / `cannot-verify`)
- Phase 1 strict on AC extraction — no explicit AC section means `not-applicable`, never invented criteria
- Phase 2 attempts cheapest credible verification per scenario; structured manual-handoff format when the model can't run something
- Phase 3 returns `not-applicable` (and is omitted from the report) when no design source of truth exists
- Phase 4 adopts Google's 12 review categories and the "code health > perfection" principle, with severity labels (`Critical` / `Important` / `Nit:` / `Optional:` / `Consider:` / `FYI:` / `Praise:`)
- Posting workflow preserved: private draft → interactive discussion → explicit user approval → inline GitHub comments
- `buildDocs.copySkillFiles` updated to recursively copy every file in each skill directory (was: only `SKILL.md`); `.md` files get `{{var}}` substitution, others copy verbatim; per-file errors warn-and-continue

## Evidence

- `npm run typecheck` clean
- `npm run build` clean
- `node dist/bin/codery.js build --force` emits all 5 audit files to `.claude/skills/codery-audit/` (SKILL.md + 4 phase playbooks)
- Dry-run on PR #45 / COD-61 via subagent loading the new skill from disk: produced a complete consolidated report (verdict, status table, per-phase findings) — surfaced 1 Important finding (POSIX normalization mismatch in `documentationRoots` resolution that doesn't exist for `applicationDocs`), 3 Nits, 2 Optional, 3 Praise. Phase 3 correctly returned `not-applicable`. Full report posted as `[Autopilot/Verify]` comment on COD-62.

## How to Verify

1. Pull the branch + `npm run build`
2. From this repo: `node dist/bin/codery.js build --force` — confirm 5 files appear under `.claude/skills/codery-audit/`
3. Read `codery-docs/.codery/skills/codery-audit/SKILL.md` — confirm it's the thin orchestrator (~100 lines) referencing each phase file by name
4. Optional: invoke `/codery-audit 45` and confirm output matches the dry-run shape captured on COD-62

## Reviewer Guidance

- The design work happened in the brainstorming session captured on COD-62 — 4 open questions resolved with the user before any code was written; advisor() second-opinion call before Builder
- The `buildDocs.ts` change is small but lands a missing capability — companion files in skill directories were silently dropped before. No existing skills relied on companion files, so no regression risk for the other 8 skills
- Skill prose follows the principle-driven authorship pattern (Goal → Signals → Principles → Anti-patterns → Output) per saved feedback
- Created as **draft PR** per autopilot's "draft endpoint" rule