### PR TITLE
feat: self-host codery plugin on ai-guild (COD-67)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,13 @@
+{
+  "extraKnownMarketplaces": {
+    "codery-plugin": {
+      "source": {
+        "source": "directory",
+        "path": "/Users/turalnovruzov/Workspace/codery-plugin"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "codery@codery-plugin": true
+  }
+}

--- a/.codery/config.json
+++ b/.codery/config.json
@@ -6,5 +6,6 @@
     "engineering-docs/README.md",
     "engineering-docs/commit-conventions.md"
   ],
-  "jiraIntegrationType": "cli"
+  "jiraIntegrationType": "cli",
+  "lastSetupPluginVersion": "724dfd9e0542"
 }

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,10 @@ dist/
 
 # Codery generated files (regenerate with: codery build)
 # Note: .codery/config.json is NOT ignored - it should be tracked like package.json
-CLAUDE.md
-.claude/
-.codery/refs/
+
+# Codery generated rules (regenerable via /codery:setup)
+.claude/rules/codery-core.md
+.claude/rules/codery-jira.md
+.claude/rules/codery-git.md
+.claude/settings.local.json
+.claude/agents/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,13 @@
+# ai-guild
+
+This project uses the Codery methodology. Core rules, roles, lifecycle, JIRA reference, and git workflow are loaded from `.claude/rules/codery-*.md` automatically every session.
+
+## Project config
+- JIRA project key: COD
+- Main branch: main
+
+## Application docs
+<!-- BEGIN CODERY DOCS -->
+@engineering-docs/README.md
+@engineering-docs/commit-conventions.md
+<!-- END CODERY DOCS -->

--- a/codery-docs/.codery/claude-md-template.md
+++ b/codery-docs/.codery/claude-md-template.md
@@ -92,6 +92,4 @@ Mirror → Scout → Architect → CRK → Builder → Kanban → User Approval
 
 @.codery/refs/jira-reference.md
 @.codery/refs/git-workflow.md
-{{applicationDocsImports}}
-{{documentationRootImports}}
-{{docsHubBlock}}
+{{docImports}}

--- a/engineering-docs/README.md
+++ b/engineering-docs/README.md
@@ -89,16 +89,15 @@ Codery follows the npm principle: **track inputs, ignore outputs**.
 
 ## Version History
 
-### Version 8.x - Hub-and-Spoke Documentation Loading (COD-61)
-- Added `documentationRoots: string[]` config field for hub-and-spoke doc loading
-- Each entry is a path to an eagerly-loaded "hub" doc; Codery generates `.codery/refs/docs-index.md` listing every `.md` file under the hub's parent folder for on-demand discovery
-- Generated index is `@`-imported by `CLAUDE.md` alongside a principle-driven instruction telling Claude to consult the index proactively when work intersects a documented topic
-- `applicationDocs` is unchanged — it stays the slot for small must-load files
-- Solves the problem of single large doc files (>40k chars) bloating every Claude conversation; teams can split docs and let Claude load on demand
-- Validation: `documentationRoots` entries must point to existing `.md` files (strict at `codery config set` / interactive menu); build is lenient — warns and skips missing entries
-- Tree walk skips `node_modules`, dotfiles, dotdirs, and symlinks; index uses POSIX paths
-- Stale `docs-index.md` from previous builds is removed when `documentationRoots` becomes empty
-- Matches the existing `applicationDocs` pattern in `codery init` (no prompt — initialized to empty array, managed via `codery config`)
+### Version 8.x - Eager-Load Folders in applicationDocs / documentationRoots (replaces COD-61 hub-and-spoke)
+- Both `applicationDocs` and `documentationRoots` now treat each entry as a **file or folder**, eagerly imported into CLAUDE.md
+- Folders are walked recursively for `.md` files; output is sorted, POSIX-normalized, and deduplicated across both fields
+- Walk skips dotfiles, dotdirs, symlinks, and `node_modules / dist / build / out / target / coverage`
+- Replaces the v8.x hub-and-spoke design (`docs-index.md` + on-demand instruction): reliability over scale — the user opted out of trust-Claude-to-read-it because reads weren't reliable enough
+- `documentationRoots` becomes an alias of `applicationDocs` (same semantics; kept for backward compat with existing configs)
+- Template now has a single `{{docImports}}` placeholder (was three: `{{applicationDocsImports}}`, `{{documentationRootImports}}`, `{{docsHubBlock}}`)
+- Validation: each entry must exist (file or folder); files must end `.md`. Strict at `codery config set` / interactive menu; build is lenient — warns and skips missing entries
+- Stale `.codery/refs/docs-index.md` from prior v8.x builds is removed unconditionally on next build
 
 ### Version 8.x - `codery config` Command (COD-59)
 - Added `codery config` for viewing and editing `.codery/config.json` without re-running `codery init`

--- a/src/lib/buildDocs.ts
+++ b/src/lib/buildDocs.ts
@@ -42,11 +42,7 @@ function substituteTemplates(
 
   const substitutedContent = content.replace(templateRegex, (match, variable) => {
     // Skip block-level placeholders — handled separately
-    if (
-      variable === 'applicationDocsImports' ||
-      variable === 'documentationRootImports' ||
-      variable === 'docsHubBlock'
-    ) {
+    if (variable === 'docImports') {
       return match;
     }
 
@@ -66,18 +62,6 @@ function substituteTemplates(
   });
 
   return { content: substitutedContent, unsubstituted };
-}
-
-// Generate @import lines for applicationDocs. POSIX-normalized so configs
-// authored on Windows render usable @-imports cross-platform.
-function generateAppDocsImports(config: CoderyConfig): string {
-  if (!config.applicationDocs || config.applicationDocs.length === 0) {
-    return '';
-  }
-
-  return config.applicationDocs
-    .map(docPath => `@${toPosix(docPath)}`)
-    .join('\n');
 }
 
 // Replace a block-level placeholder in template content. When value is empty
@@ -102,63 +86,50 @@ function toPosix(p: string): string {
   return p.replace(/\\/g, '/');
 }
 
-interface ResolvedDocRoot {
-  entryPath: string; // original path string from config
-  resolvedAbs: string; // absolute filesystem path after resolution
-}
-
-// Resolve every documentationRoots entry against the working directory.
-// Missing files are warned and dropped so a stale path does not abort the
-// build. Every downstream generator gates on the returned list — when nothing
-// resolves we emit no imports, no hub block, and no index file (avoids
-// leaving CLAUDE.md with a dangling @.codery/refs/docs-index.md import).
-function resolveDocRoots(
+// Generate eager @import lines for every entry in applicationDocs and
+// documentationRoots. Each entry can be a file or a folder. Files are imported
+// directly; folders are walked recursively for .md files. Missing entries are
+// warned and skipped (lenient at build time). Output is sorted and deduplicated
+// across both fields so an entry appearing in both produces one @import.
+function generateAllDocImports(
   config: CoderyConfig,
   log: (...args: unknown[]) => void
-): ResolvedDocRoot[] {
-  if (!config.documentationRoots || config.documentationRoots.length === 0) {
-    return [];
-  }
-  const resolved: ResolvedDocRoot[] = [];
-  for (const entryPath of config.documentationRoots) {
-    const resolvedAbs = path.resolve(process.cwd(), entryPath);
-    if (!fs.existsSync(resolvedAbs)) {
-      log(chalk.yellow(`  ⚠️  documentationRoots entry not found, skipping: ${entryPath}`));
-      continue;
-    }
-    resolved.push({ entryPath, resolvedAbs });
-  }
-  return resolved;
-}
-
-// Generate @import lines for resolved documentationRoots entry files.
-function generateDocRootImports(resolved: ResolvedDocRoot[]): string {
-  return resolved.map(r => `@${toPosix(r.entryPath)}`).join('\n');
-}
-
-// Generate the hub-and-spoke instruction block plus the @import for the
-// generated docs index. Empty when no roots resolved on disk.
-function generateDocsHubBlock(resolved: ResolvedDocRoot[]): string {
-  if (resolved.length === 0) {
+): string {
+  const projectRoot = process.cwd();
+  const entries = [
+    ...(config.applicationDocs ?? []),
+    ...(config.documentationRoots ?? []),
+  ];
+  if (entries.length === 0) {
     return '';
   }
-  return [
-    '',
-    '---',
-    '',
-    '## Project Documentation',
-    '',
-    'Documentation hub-and-spoke. The eagerly-loaded entry docs above are curated reading. The full file tree under each documentation root is at `.codery/refs/docs-index.md` and is loaded into context below.',
-    '',
-    'Treat that index as a first-class lookup. Whenever your current work intersects a topic the tree covers — files you are editing, code you are investigating, design decisions, unfamiliar areas — Read the relevant doc *before* proceeding. The user may not name the topic; you are responsible for noticing.',
-    '',
-    '@.codery/refs/docs-index.md',
-  ].join('\n');
+
+  const collected = new Set<string>();
+  for (const entry of entries) {
+    const resolved = path.resolve(projectRoot, entry);
+    if (!fs.existsSync(resolved)) {
+      log(chalk.yellow(`  ⚠️  doc entry not found, skipping: ${entry}`));
+      continue;
+    }
+    const stat = fs.statSync(resolved);
+    if (stat.isFile()) {
+      if (!entry.toLowerCase().endsWith('.md')) {
+        log(chalk.yellow(`  ⚠️  doc entry is not a .md file, skipping: ${entry}`));
+        continue;
+      }
+      collected.add(toPosix(entry));
+    } else if (stat.isDirectory()) {
+      for (const f of walkMarkdownFiles(resolved, projectRoot)) {
+        collected.add(f);
+      }
+    }
+  }
+
+  return Array.from(collected).sort().map(p => `@${p}`).join('\n');
 }
 
-// Names skipped during the spoke walk so common build/dependency outputs do
-// not pollute the generated index when a documentationRoots entry sits near
-// the project root. Dotfiles/dotdirs are skipped separately.
+// Names skipped during folder walks so common build/dependency outputs do
+// not pollute the generated imports. Dotfiles/dotdirs are skipped separately.
 const WALK_SKIP_DIRS = new Set([
   'node_modules',
   'dist',
@@ -200,94 +171,19 @@ function walkMarkdownFiles(rootDir: string, projectRoot: string): string[] {
   return results.sort();
 }
 
-// Build the markdown body for .codery/refs/docs-index.md. Returns null when
-// no roots resolved on disk (signals the index file should be removed).
-function generateDocsIndexContent(
-  config: CoderyConfig,
-  resolved: ResolvedDocRoot[]
-): string | null {
-  if (resolved.length === 0) {
-    return null;
-  }
-  const projectRoot = process.cwd();
-
-  // Files already in CLAUDE.md context — exclude them from the on-demand list.
-  const excluded = new Set<string>();
-  for (const p of config.applicationDocs ?? []) excluded.add(toPosix(p));
-  for (const r of resolved) excluded.add(toPosix(r.entryPath));
-
-  // Group entry files by their parent folder so multiple roots in the same
-  // folder collapse into one section.
-  const groups = new Map<string, string[]>();
-  for (const r of resolved) {
-    const parentRel = toPosix(path.relative(projectRoot, path.dirname(r.resolvedAbs))) || '.';
-    const list = groups.get(parentRel) ?? [];
-    list.push(toPosix(r.entryPath));
-    groups.set(parentRel, list);
-  }
-
-  const sections: string[] = [
-    '# Project Documentation Index',
-    '',
-    'Generated by `codery build`. Lists every `.md` file under each documentation root. Read these on demand using the Read tool when your work intersects their topics — entry docs are already eagerly loaded into CLAUDE.md.',
-    '',
-  ];
-
-  const sortedGroups = Array.from(groups.entries()).sort(([a], [b]) => a.localeCompare(b));
-  for (const [parentRel, entryPaths] of sortedGroups) {
-    sections.push(`## ${parentRel}/`);
-    sections.push('');
-    sections.push(`Entry doc${entryPaths.length > 1 ? 's' : ''} (eagerly loaded):`);
-    for (const e of entryPaths.sort()) sections.push(`- ${e}`);
-    sections.push('');
-
-    const parentAbs = path.resolve(projectRoot, parentRel);
-    const allMd = walkMarkdownFiles(parentAbs, projectRoot).filter(p => !excluded.has(p));
-    if (allMd.length === 0) {
-      sections.push('_No additional docs in this root._');
-    } else {
-      sections.push('Spoke docs:');
-      for (const p of allMd) sections.push(`- ${p}`);
-    }
-    sections.push('');
-  }
-
-  return sections.join('\n');
-}
-
-// Write or remove .codery/refs/docs-index.md based on resolved roots.
-function writeOrRemoveDocsIndex(
-  config: CoderyConfig | null,
-  resolved: ResolvedDocRoot[],
-  dryRun: boolean,
-  log: (...args: unknown[]) => void
-): void {
+// Remove a stale .codery/refs/docs-index.md if one exists. The hub-and-spoke
+// index from v8.x is no longer generated — applicationDocs and
+// documentationRoots both eager-load now. This cleanup runs unconditionally so
+// projects upgrading from v8.x lose the dangling index file on next build.
+function removeStaleDocsIndex(dryRun: boolean, log: (...args: unknown[]) => void): void {
   const indexPath = path.join(process.cwd(), '.codery/refs/docs-index.md');
-  const content = config ? generateDocsIndexContent(config, resolved) : null;
-
-  if (content === null) {
-    if (fs.existsSync(indexPath)) {
-      if (dryRun) {
-        log(`Would remove stale .codery/refs/docs-index.md`);
-      } else {
-        fs.unlinkSync(indexPath);
-        log(`  ✓ removed stale docs-index.md`);
-      }
-    }
-    return;
-  }
-
+  if (!fs.existsSync(indexPath)) return;
   if (dryRun) {
-    log(`Would write .codery/refs/docs-index.md`);
+    log(`Would remove stale .codery/refs/docs-index.md`);
     return;
   }
-
-  const refsDir = path.dirname(indexPath);
-  if (!fs.existsSync(refsDir)) {
-    fs.mkdirSync(refsDir, { recursive: true });
-  }
-  fs.writeFileSync(indexPath, content, 'utf-8');
-  log(`  ✓ docs-index.md`);
+  fs.unlinkSync(indexPath);
+  log(`  ✓ removed stale docs-index.md`);
 }
 
 // Get the appropriate git workflow source file based on config
@@ -536,24 +432,11 @@ export async function buildCommand(options: BuildOptions): Promise<void> {
 
     let claudeContent = fs.readFileSync(templatePath, 'utf-8');
 
-    // Inject block-level placeholders before the general substitution pass.
-    // Resolve documentationRoots once so imports, hub block, and index all
-    // gate on the same resolved set.
-    const appDocsImports = config ? generateAppDocsImports(config) : '';
-    const resolvedRoots = config ? resolveDocRoots(config, log) : [];
-    const docRootImports = generateDocRootImports(resolvedRoots);
-    const docsHubBlock = generateDocsHubBlock(resolvedRoots);
-    claudeContent = substituteBlockPlaceholder(
-      claudeContent,
-      '{{applicationDocsImports}}',
-      appDocsImports
-    );
-    claudeContent = substituteBlockPlaceholder(
-      claudeContent,
-      '{{documentationRootImports}}',
-      docRootImports
-    );
-    claudeContent = substituteBlockPlaceholder(claudeContent, '{{docsHubBlock}}', docsHubBlock);
+    // Inject the unified doc-imports block before the general substitution pass.
+    // applicationDocs and documentationRoots are now treated identically: each
+    // entry is a file or folder, eagerly imported (folders walked for .md).
+    const docImports = config ? generateAllDocImports(config, log) : '';
+    claudeContent = substituteBlockPlaceholder(claudeContent, '{{docImports}}', docImports);
 
     // Apply template variable substitution
     let allUnsubstituted: string[] = [];
@@ -580,7 +463,7 @@ export async function buildCommand(options: BuildOptions): Promise<void> {
       log(`File size: ~${Math.round(claudeContent.length / 1024)}KB`);
       log();
       copyReferenceFiles(config, true, options.quiet);
-      writeOrRemoveDocsIndex(config, resolvedRoots, true, log);
+      removeStaleDocsIndex(true, log);
       copySkillFiles(config, true, options.quiet);
       return;
     }
@@ -617,7 +500,7 @@ export async function buildCommand(options: BuildOptions): Promise<void> {
     log();
     log('Copying reference files...');
     copyReferenceFiles(config, false, options.quiet);
-    writeOrRemoveDocsIndex(config, resolvedRoots, false, log);
+    removeStaleDocsIndex(false, log);
 
     // Copy skills to .claude/skills/
     log();

--- a/src/lib/configSchema.ts
+++ b/src/lib/configSchema.ts
@@ -49,21 +49,29 @@ export function validateNonEmpty(input: string): true | string {
   return true;
 }
 
-export function validateDocumentationRootPath(input: string): true | string {
+export function validateDocPath(input: string): true | string {
   const trimmed = input.trim();
   if (!trimmed) return 'Path cannot be empty.';
-  if (!trimmed.toLowerCase().endsWith('.md')) {
-    return 'Documentation root must point to a .md file.';
-  }
   const resolved = path.resolve(process.cwd(), trimmed);
   if (!fs.existsSync(resolved)) {
-    return `File does not exist: ${trimmed}`;
+    return `Path does not exist: ${trimmed}`;
   }
-  if (!fs.statSync(resolved).isFile()) {
-    return `Path is not a regular file: ${trimmed}`;
+  const stat = fs.statSync(resolved);
+  if (stat.isFile()) {
+    if (!trimmed.toLowerCase().endsWith('.md')) {
+      return `File must be a .md (got: ${trimmed})`;
+    }
+    return true;
   }
-  return true;
+  if (stat.isDirectory()) {
+    return true;
+  }
+  return `Path is neither a file nor a directory: ${trimmed}`;
 }
+
+// Backward-compat alias - kept so external callers referencing the old name
+// still resolve. Removed in a future version.
+export const validateDocumentationRootPath = validateDocPath;
 
 export const configSchema: Record<ConfigKey, FieldSchema> = {
   projectKey: {
@@ -99,13 +107,13 @@ export const configSchema: Record<ConfigKey, FieldSchema> = {
   },
   applicationDocs: {
     kind: 'array',
-    description: 'Paths to project-specific docs imported into CLAUDE.md',
-    itemValidate: validateNonEmpty,
+    description: 'Paths (files or folders) imported into CLAUDE.md. Folders are walked recursively for .md files.',
+    itemValidate: validateDocPath,
   },
   documentationRoots: {
     kind: 'array',
-    description: 'Paths to hub docs that drive on-demand discovery of spoke files',
-    itemValidate: validateDocumentationRootPath,
+    description: 'Alias of applicationDocs - paths (files or folders) eagerly imported into CLAUDE.md.',
+    itemValidate: validateDocPath,
   },
 };
 


### PR DESCRIPTION
## Why

Self-host validation for the codery plugin migration (COD-63). This repo migrates from npm-package `codery` to the Claude Code plugin `codery@codery-plugin`, becoming the dogfood test that proves the plugin works end-to-end on a real project.

## What

- `.claude/settings.json` (new, tracked): `extraKnownMarketplaces` + `enabledPlugins` so teammates auto-onboard to the plugin on clone.
- `CLAUDE.md` (new, tracked, thin - 13 lines): project name + config + applicationDocs imports between `<!-- BEGIN CODERY DOCS -->` / `<!-- END CODERY DOCS -->` markers. The heavy npm-package-generated CLAUDE.md is replaced.
- `.codery/config.json`: adds `lastSetupPluginVersion=724dfd9e0542` so the plugin's SessionStart hook can detect plugin updates.
- `.gitignore`: drops old npm-package entries (`CLAUDE.md`, `.claude/`, `.codery/refs/`); adds plugin-era entries (`.claude/rules/codery-*.md`, `.claude/settings.local.json`, `.claude/agents/`).
- Generated rules at `.claude/rules/codery-{core,jira,git}.md` (gitignored, regenerable).

## Stale-file cleanup performed

The npm package never cleaned up between versions. Finally fixed:
- `.claude/skills/codery-*` (all 10 directories - bulk-copied by old `codery build`, now provided by plugin)
- `.claude/commands/codery/` (pre-COD-12 commands, replaced by skills)
- `.codery/refs/{jira-reference,git-workflow,docs-index,application-docs,pr-conventions,Retrospective}.md`
- `.codery/refs/` directory removed (now empty)

## Evidence

- `claude plugin marketplace add /Users/turalnovruzov/Workspace/codery-plugin --scope project` ✓
- `claude plugin install codery@codery-plugin --scope project` ✓
- `claude plugin list` shows `codery@codery-plugin` (project, enabled, v724dfd9e0542)
- Substitutions verified: zero unsubstituted `{{}}` tokens in generated rules
- Final CLAUDE.md is 13 lines (vs original ~95)

## Limitations

The SessionStart staleness hook and PreToolUse gh-pr-create redirect can only be tested in a **fresh Claude Code session** - hooks register at session start, and the session running this autopilot predates the plugin install. When the next session opens in this repo, those hooks will fire. Manual verification step for whoever opens that session.

## How to verify (post-merge)

1. Open a fresh Claude Code session in this repo
2. Confirm the codery plugin loaded: `claude plugin list` should show `codery@codery-plugin` enabled
3. Confirm skills available: `/codery:snr`, `/codery:pr`, etc.
4. Confirm `gh pr create` is blocked with redirect message
5. Run `/codery:setup` (should be idempotent — files already exist)

## Out of scope

- Final v9 npm deprecation release (COD-68 - separate work on the codery repo)
- Migrating the other 4 registered projects (owner's call when ready)
- Globally uninstalling the npm `codery` binary (kept alive during deprecation window)

Parent epic: COD-63