### PR TITLE
feat!: deprecate codery npm package, redirect to plugin (COD-68)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,25 @@
 [![npm version](https://img.shields.io/npm/v/codery.svg)](https://www.npmjs.com/package/codery)
 [![License: ISC](https://img.shields.io/badge/License-ISC-blue.svg)](https://opensource.org/licenses/ISC)
 
+> **⚠️ DEPRECATED — moved to a Claude Code plugin (v9.0.0+).** The Codery methodology and skills are now distributed natively via Claude Code's plugin system. The npm package is in deprecation. See **[turalnovruzov/codery-plugin](https://github.com/turalnovruzov/codery-plugin)** for the new home.
+
+## Migrate to the plugin
+
+```text
+/plugin marketplace add turalnovruzov/codery-plugin
+/plugin install codery@codery-plugin
+/codery:setup
+```
+
+That's it — `/codery:setup` writes your project config and rules files and replaces everything `codery init` + `codery build` + `codery update` did before.
+
+---
+
+## Below this line: legacy v8.x documentation (npm package)
+
 Codery is a comprehensive development methodology and workflow system designed to enable AI agents (like Claude) to work effectively with human developers on software projects.
 
-## Installation
+## Installation (legacy v8.x)
 
 ```bash
 npm install -g codery

--- a/src/bin/codery.ts
+++ b/src/bin/codery.ts
@@ -1,235 +1,32 @@
 #!/usr/bin/env node
 
-import * as fs from 'fs';
-import * as path from 'path';
-import { Command } from 'commander';
+// v9.0.0 — Deprecation shim. Codery has moved to a Claude Code plugin. Every
+// command in this binary prints the migration message and exits 0. The package
+// stays on npm during the deprecation window so the team has time to migrate;
+// see COD-63 for the full migration epic.
+
 import chalk from 'chalk';
-import { buildCommand } from '../lib/buildDocs';
-import { initCommand } from '../lib/initCommand';
-import { updateCommand } from '../lib/updateCommand';
-import {
-  configList,
-  configGet,
-  configSet,
-  configUnset,
-  configAdd,
-  configRemove,
-  configMenu,
-} from '../lib/configCommand';
-import { addProject, removeProject, listProjects, projectExists } from '../lib/registry';
 
-// Read version from package.json
-const packageJsonPath = path.resolve(__dirname, '../../package.json');
-const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
+const message = [
+  '',
+  chalk.yellow.bold('Codery has moved to a Claude Code plugin.'),
+  '',
+  'This npm package (v9.x) is deprecated. The Codery methodology and skills',
+  'are now distributed as a native Claude Code plugin.',
+  '',
+  chalk.bold('To migrate:'),
+  '  1. Open Claude Code in your project.',
+  '  2. /plugin marketplace add turalnovruzov/codery-plugin',
+  '  3. /plugin install codery@codery-plugin',
+  '  4. /codery:setup',
+  '',
+  chalk.bold('Documentation:'),
+  '  https://github.com/turalnovruzov/codery-plugin',
+  '',
+  chalk.dim('The npm package will remain on the registry through the deprecation window.'),
+  chalk.dim('Once the team has migrated, the package will be archived and unpublished.'),
+  '',
+].join('\n');
 
-const program = new Command();
-
-program
-  .name('codery')
-  .description('Codery CLI - Build AI development workflows for your project')
-  .version(packageJson.version);
-
-program
-  .command('init')
-  .description('Initialize Codery configuration in your project')
-  .option('--force', 'Overwrite existing configuration without prompting')
-  .action(async options => {
-    try {
-      await initCommand(options);
-    } catch (error: any) {
-      console.error(chalk.red('Error:'), error.message);
-      process.exit(1);
-    }
-  });
-
-program
-  .command('build')
-  .description('Build a CLAUDE.md file from Codery documentation')
-  .option('--output <path>', 'Output path for CLAUDE.md file (default: ./CLAUDE.md)')
-  .option('--dry-run', 'Show what would be built without creating the file')
-  .option('--skip-config', 'Build without template substitution')
-  .option('--force', 'Overwrite existing files without prompting')
-  .action(async options => {
-    try {
-      await buildCommand(options);
-    } catch (error: any) {
-      console.error(chalk.red('Error:'), error.message);
-      process.exit(1);
-    }
-  });
-
-program
-  .command('update')
-  .description('Update Codery and rebuild all registered projects')
-  .option('--yes', 'Auto-remove missing projects without prompting')
-  .action(async options => {
-    try {
-      await updateCommand(options);
-    } catch (error: any) {
-      console.error(chalk.red('Error:'), error.message);
-      process.exit(1);
-    }
-  });
-
-program
-  .command('register [path]')
-  .description('Register a project for updates (defaults to current directory)')
-  .action((projectPath?: string) => {
-    try {
-      const targetPath = projectPath || process.cwd();
-      const added = addProject(targetPath);
-
-      if (added) {
-        console.log(chalk.green('✓'), `Registered: ${targetPath}`);
-      } else {
-        console.log(chalk.dim('Already registered:'), targetPath);
-      }
-    } catch (error: any) {
-      console.error(chalk.red('Error:'), error.message);
-      process.exit(1);
-    }
-  });
-
-program
-  .command('unregister [path]')
-  .description('Remove a project from the registry (defaults to current directory)')
-  .action((projectPath?: string) => {
-    try {
-      const targetPath = projectPath || process.cwd();
-      const removed = removeProject(targetPath);
-
-      if (removed) {
-        console.log(chalk.green('✓'), `Unregistered: ${targetPath}`);
-      } else {
-        console.log(chalk.yellow('Not found in registry:'), targetPath);
-      }
-    } catch (error: any) {
-      console.error(chalk.red('Error:'), error.message);
-      process.exit(1);
-    }
-  });
-
-program
-  .command('list')
-  .description('List all registered Codery projects')
-  .action(() => {
-    try {
-      const projects = listProjects();
-
-      if (projects.length === 0) {
-        console.log(chalk.yellow('No projects registered.'));
-        console.log(
-          chalk.dim('Run `codery init` in a project or `codery register` to add projects.')
-        );
-        return;
-      }
-
-      console.log('Registered Codery projects:');
-      console.log();
-
-      projects.forEach((project, index) => {
-        const exists = projectExists(project.path);
-        const status = exists ? '' : chalk.red(' (not found)');
-        console.log(`  ${index + 1}. ${project.path}${status}`);
-      });
-
-      console.log();
-      console.log(`${projects.length} project(s) registered`);
-    } catch (error: any) {
-      console.error(chalk.red('Error:'), error.message);
-      process.exit(1);
-    }
-  });
-
-const configCmd = program.command('config').description('View or edit Codery configuration');
-
-configCmd
-  .command('menu', { isDefault: true })
-  .description('Open interactive config menu (default)')
-  .action(async () => {
-    try {
-      await configMenu();
-    } catch (error: any) {
-      console.error(chalk.red('Error:'), error.message);
-      process.exit(1);
-    }
-  });
-
-configCmd
-  .command('list')
-  .description('Print the full configuration as JSON')
-  .action(() => {
-    try {
-      configList();
-    } catch (error: any) {
-      console.error(chalk.red('Error:'), error.message);
-      process.exit(1);
-    }
-  });
-
-configCmd
-  .command('get <key>')
-  .description('Print the value of a single config field')
-  .action((key: string) => {
-    try {
-      configGet(key);
-    } catch (error: any) {
-      console.error(chalk.red('Error:'), error.message);
-      process.exit(1);
-    }
-  });
-
-configCmd
-  .command('set <key> <value>')
-  .description('Set a scalar config field')
-  .action((key: string, value: string) => {
-    try {
-      configSet(key, value);
-    } catch (error: any) {
-      console.error(chalk.red('Error:'), error.message);
-      process.exit(1);
-    }
-  });
-
-configCmd
-  .command('unset <key>')
-  .description('Remove a config field')
-  .action((key: string) => {
-    try {
-      configUnset(key);
-    } catch (error: any) {
-      console.error(chalk.red('Error:'), error.message);
-      process.exit(1);
-    }
-  });
-
-configCmd
-  .command('add <key> <value>')
-  .description('Append a value to an array config field (e.g., applicationDocs)')
-  .action((key: string, value: string) => {
-    try {
-      configAdd(key, value);
-    } catch (error: any) {
-      console.error(chalk.red('Error:'), error.message);
-      process.exit(1);
-    }
-  });
-
-configCmd
-  .command('remove <key> <value>')
-  .description('Remove a value from an array config field')
-  .action((key: string, value: string) => {
-    try {
-      configRemove(key, value);
-    } catch (error: any) {
-      console.error(chalk.red('Error:'), error.message);
-      process.exit(1);
-    }
-  });
-
-program.parse(process.argv);
-
-// Show help if no command is provided
-if (program.args.length === 0) {
-  program.help();
-}
+console.log(message);
+process.exit(0);


### PR DESCRIPTION
## Why

Final step of the Codery plugin migration epic (COD-63). The methodology and skills now live in the `codery-plugin` Claude Code plugin. This PR turns the npm package into a deprecation shim: every command prints the migration message and exits 0.

## What

- `src/bin/codery.ts` replaced with a 30-line deprecation shim. All previous commands (init, build, update, register, unregister, list, config and subcommands) print the move message and exit 0.
- `README.md` gets a deprecation banner with the migration one-liner. Legacy v8.x docs preserved below for reference during the deprecation window.

## Migration message users see

```
Codery has moved to a Claude Code plugin.

This npm package (v9.x) is deprecated. The Codery methodology and skills
are now distributed as a native Claude Code plugin.

To migrate:
  1. Open Claude Code in your project.
  2. /plugin marketplace add turalnovruzov/codery-plugin
  3. /plugin install codery@codery-plugin
  4. /codery:setup

Documentation:
  https://github.com/turalnovruzov/codery-plugin

The npm package will remain on the registry through the deprecation window.
Once the team has migrated, the package will be archived and unpublished.
```

## Evidence

- `npm run typecheck` passes
- `npm run build` clean
- Tested all old commands: `node dist/bin/codery.js init`, `build`, `config list` — all print message and exit 0

## Post-merge action (manual)

After semantic-release publishes v9.0.0, run:

```bash
npm deprecate codery@9.0.0 "Moved to https://github.com/turalnovruzov/codery-plugin"
```

This surfaces the deprecation notice during `npm install codery` and is the npm-canonical deprecation mechanism.

## Out of scope

- Removing the dead TS modules (buildDocs.ts, initCommand.ts, etc.) - they still compile, just aren't imported. Cleanup can happen later if desired.
- Archiving the GitHub repo or unpublishing from npm - happens after the deprecation window per Q4 epic decision.

## Closes the epic

This is the last task in COD-63. Sequence: COD-64 (scaffold) ✓ COD-65 (/codery:setup) ✓ COD-66 (/codery:config + hooks) ✓ COD-67 (self-host) ✓ COD-68 (this PR).

Parent epic: COD-63

BREAKING CHANGE: Codery CLI commands no longer execute their previous behavior — they print a deprecation message and exit 0. Install the Claude Code plugin to continue using Codery (`/plugin install codery@codery-plugin`).